### PR TITLE
Q-Sylvan 1.2.0 with Sylvan 1.8.0 base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Change Log
+All notable changes to Q-Sylvan are documented in this file.
+
+## [1.2.0] - 2023-08-05
+### Changed
+- Add Sylvan 1.8.0 base
+- 
+
+## [1.1.0] - 2022-12-21
+### Changed
+- Add Sylvan 1.7.1 base
+- 
+
+## [1.0.1] - 2021-08-12
+### Changed
+- Add QASM support
+- 
+
+
+## [1.0.0] - 2020-09-29
+- 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(qsylvan  # based on sylvan 1.7.1
-    VERSION 1.1.0
+project(qsylvan  # based on sylvan 1.8.0
+    VERSION 1.2.0
     DESCRIPTION "Sylvan, a parallel decision diagram library"
     HOMEPAGE_URL "https://github.com/trolando/sylvan"
     LANGUAGES C CXX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(FetchContent)
 FetchContent_Declare(
     lace
     GIT_REPOSITORY https://github.com/trolando/lace.git
-    GIT_TAG        v1.3.1
+    GIT_TAG        v1.4.0
 )
 FetchContent_MakeAvailable(lace)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,18 @@ target_compile_options(qsylvan PRIVATE -Wall -Wextra -Werror -fno-strict-aliasin
 target_include_directories(qsylvan PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 target_link_libraries(qsylvan PUBLIC m pthread lace edge_weight_storage)
 
+option(SYLVAN_USE_MMAP "Let Sylvan use mmap to allocate (virtual) memory" ON)
+if(SYLVAN_USE_MMAP)
+    include(CheckSymbolExists)
+    check_symbol_exists(mmap "sys/mman.h" HAVE_MMAP)
+    if(NOT HAVE_MMAP)
+        message(WARNING " mmap not found: disabling mmap support")
+        set(SYLVAN_USE_MMAP OFF)
+    else()
+        set_target_properties(qsylvan PROPERTIES COMPILE_DEFINITIONS "SYLVAN_USE_MMAP")
+    endif()
+endif()
+
 find_package(GMP REQUIRED)
 target_sources(qsylvan PRIVATE sylvan_gmp.c PUBLIC sylvan_gmp.h)
 target_include_directories(qsylvan PRIVATE ${GMP_INCLUDE_DIR})

--- a/src/edge_weight_storage/flt.h
+++ b/src/edge_weight_storage/flt.h
@@ -62,8 +62,8 @@ static inline complex_t cmake_angle(fl_t theta, fl_t mag)
     c.i = flt_sin(theta) * mag;
     return c;
 }
-static inline complex_t czero() { return cmake(0.0, 0.0); }
-static inline complex_t cone() { return cmake(1.0, 0.0); }
+static inline complex_t czero() { return cmake( 0.0, 0.0); }
+static inline complex_t cone()  { return cmake( 1.0, 0.0); }
 static inline complex_t cmone() { return cmake(-1.0, 0.0); }
 
 static inline complex_t cadd(complex_t a, complex_t b)

--- a/src/edge_weight_storage/wgt_storage_interface.c
+++ b/src/edge_weight_storage/wgt_storage_interface.c
@@ -2,7 +2,7 @@
 
 
 void * (*wgt_store_create)(uint64_t size, double tolerance);
-void (*wgt_store_free)();
+void (*wgt_store_free)(void *wgt_storage);
 int (*wgt_store_find_or_put)(const void *dbs, const complex_t *v, uint64_t *ret);
 complex_t (*wgt_store_get)(const void *dbs, const uint64_t ref);
 uint64_t (*wgt_store_num_entries)(const void *dbs);

--- a/src/edge_weight_storage/wgt_storage_interface.h
+++ b/src/edge_weight_storage/wgt_storage_interface.h
@@ -17,7 +17,7 @@ typedef enum wgt_storage_backend {
 extern void * (*wgt_store_create)(uint64_t size, double tolerance);
 
 // free
-extern void (*wgt_store_free)();
+extern void (*wgt_store_free)(void *wgt_storage);
 
 // find_or_put(void *dbs, complex_t *v, int *ret)
 extern int (*wgt_store_find_or_put)(const void *dbs, const complex_t *v, uint64_t *ret);

--- a/src/qsylvan_gates.c
+++ b/src/qsylvan_gates.c
@@ -1,5 +1,6 @@
 #include <qsylvan_gates.h>
 #include <sylvan_int.h>
+#include <sylvan_edge_weights_complex.h>
 
 
 static long double Pi;    // set value of global Pi
@@ -31,8 +32,8 @@ GATEID_Rz(fl_t a)
     // initialize gate
     double theta_over_2 = Pi * a;
     AMP u00, u11;
-    u00 = weight_lookup(cmake_angle(-theta_over_2, 1));
-    u11 = weight_lookup(cmake_angle(theta_over_2, 1));
+    u00 = complex_lookup_angle(-theta_over_2, 1);
+    u11 = complex_lookup_angle(theta_over_2, 1);
     gates[gate_id][0] = u00;    gates[gate_id][1] = AADD_ZERO;
     gates[gate_id][2] = AADD_ZERO; gates[gate_id][3] = u11;
 
@@ -49,10 +50,10 @@ GATEID_Rx(fl_t a)
     // initialize gate
     fl_t theta_over_2 = Pi * a;
     AMP u00, u01, u10, u11;
-    u00 = weight_lookup(cmake(flt_cos(theta_over_2), 0.0));
-    u01 = weight_lookup(cmake(0.0, -flt_sin(theta_over_2)));
-    u10 = weight_lookup(cmake(0.0, -flt_sin(theta_over_2)));
-    u11 = weight_lookup(cmake(flt_cos(theta_over_2), 0.0));
+    u00 = complex_lookup(flt_cos(theta_over_2), 0.0);
+    u01 = complex_lookup(0.0, -flt_sin(theta_over_2));
+    u10 = complex_lookup(0.0, -flt_sin(theta_over_2));
+    u11 = complex_lookup(flt_cos(theta_over_2), 0.0);
     gates[gate_id][0] = u00; gates[gate_id][1] = u01;
     gates[gate_id][2] = u10; gates[gate_id][3] = u11;
 
@@ -69,10 +70,10 @@ GATEID_Ry(fl_t a)
     // initialize gate
     fl_t theta_over_2 = Pi * a;
     AMP u00, u01, u10, u11;
-    u00 = weight_lookup(cmake(flt_cos(theta_over_2),  0.0));
-    u01 = weight_lookup(cmake(-flt_sin(theta_over_2), 0.0));
-    u10 = weight_lookup(cmake(flt_sin(theta_over_2),  0.0));
-    u11 = weight_lookup(cmake(flt_cos(theta_over_2),  0.0));
+    u00 = complex_lookup(flt_cos(theta_over_2),  0.0);
+    u01 = complex_lookup(-flt_sin(theta_over_2), 0.0);
+    u10 = complex_lookup(flt_sin(theta_over_2),  0.0);
+    u11 = complex_lookup(flt_cos(theta_over_2),  0.0);
     gates[gate_id][0] = u00; gates[gate_id][1] = u01;
     gates[gate_id][2] = u10; gates[gate_id][3] = u11;
 
@@ -102,48 +103,48 @@ qmdd_gates_init()
     gates[k][2] = AADD_ONE;  gates[k][3] = AADD_ZERO;
 
     k = GATEID_Y;
-    gates[k][0] = AADD_ZERO; gates[k][1] = weight_lookup(cmake(0.0, -1.0));
-    gates[k][2] = weight_lookup(cmake(0.0, 1.0));  gates[k][3] = AADD_ZERO;
+    gates[k][0] = AADD_ZERO; gates[k][1] = complex_lookup(0.0, -1.0);
+    gates[k][2] = complex_lookup(0.0, 1.0);  gates[k][3] = AADD_ZERO;
 
     k = GATEID_Z;
     gates[k][0] = AADD_ONE;  gates[k][1] = AADD_ZERO;
     gates[k][2] = AADD_ZERO; gates[k][3] = AADD_MIN_ONE;
 
     k = GATEID_H;
-    gates[k][0] = gates[k][1] = gates[k][2] = weight_lookup(cmake(1.0/flt_sqrt(2.0),0));
-    gates[k][3] = weight_lookup(cmake(-1.0/flt_sqrt(2.0),0));
+    gates[k][0] = gates[k][1] = gates[k][2] = complex_lookup(1.0/flt_sqrt(2.0),0);
+    gates[k][3] = complex_lookup(-1.0/flt_sqrt(2.0),0);
 
     k = GATEID_S;
     gates[k][0] = AADD_ONE;  gates[k][1] = AADD_ZERO;
-    gates[k][2] = AADD_ZERO; gates[k][3] = weight_lookup(cmake(0.0, 1.0));
+    gates[k][2] = AADD_ZERO; gates[k][3] = complex_lookup(0.0, 1.0);
 
     k = GATEID_Sdag;
     gates[k][0] = AADD_ONE;  gates[k][1] = AADD_ZERO;
-    gates[k][2] = AADD_ZERO; gates[k][3] = weight_lookup(cmake(0.0, -1.0));
+    gates[k][2] = AADD_ZERO; gates[k][3] = complex_lookup(0.0, -1.0);
 
     k = GATEID_T;
     gates[k][0] = AADD_ONE;  gates[k][1] = AADD_ZERO;
-    gates[k][2] = AADD_ZERO; gates[k][3] = weight_lookup(cmake(1.0/flt_sqrt(2.0), 1.0/flt_sqrt(2.0)));
+    gates[k][2] = AADD_ZERO; gates[k][3] = complex_lookup(1.0/flt_sqrt(2.0), 1.0/flt_sqrt(2.0));
 
     k = GATEID_Tdag;
     gates[k][0] = AADD_ONE;  gates[k][1] = AADD_ZERO;
-    gates[k][2] = AADD_ZERO; gates[k][3] = weight_lookup(cmake(1.0/flt_sqrt(2.0), -1.0/flt_sqrt(2.0)));
+    gates[k][2] = AADD_ZERO; gates[k][3] = complex_lookup(1.0/flt_sqrt(2.0), -1.0/flt_sqrt(2.0));
 
     k = GATEID_sqrtX;
-    gates[k][0] = weight_lookup(cmake(0.5, 0.5)); gates[k][1] = weight_lookup(cmake(0.5,-0.5));
-    gates[k][2] = weight_lookup(cmake(0.5,-0.5)); gates[k][3] = weight_lookup(cmake(0.5, 0.5));
+    gates[k][0] = complex_lookup(0.5, 0.5); gates[k][1] = complex_lookup(0.5,-0.5);
+    gates[k][2] = complex_lookup(0.5,-0.5); gates[k][3] = complex_lookup(0.5, 0.5);
 
     k = GATEID_sqrtXdag;
-    gates[k][0] = weight_lookup(cmake(0.5,-0.5)); gates[k][1] = weight_lookup(cmake(0.5, 0.5));
-    gates[k][2] = weight_lookup(cmake(0.5, 0.5)); gates[k][3] = weight_lookup(cmake(0.5,-0.5));
+    gates[k][0] = complex_lookup(0.5,-0.5); gates[k][1] = complex_lookup(0.5, 0.5);
+    gates[k][2] = complex_lookup(0.5, 0.5); gates[k][3] = complex_lookup(0.5,-0.5);
 
     k = GATEID_sqrtY;
-    gates[k][0] = weight_lookup(cmake(0.5, 0.5)); gates[k][1] = weight_lookup(cmake(-0.5,-0.5));
-    gates[k][2] = weight_lookup(cmake(0.5, 0.5)); gates[k][3] = weight_lookup(cmake(0.5, 0.5));
+    gates[k][0] = complex_lookup(0.5, 0.5); gates[k][1] = complex_lookup(-0.5,-0.5);
+    gates[k][2] = complex_lookup(0.5, 0.5); gates[k][3] = complex_lookup(0.5, 0.5);
 
     k = GATEID_sqrtYdag;
-    gates[k][0] = weight_lookup(cmake(0.5,-0.5)); gates[k][1] = weight_lookup(cmake(0.5,-0.5));
-    gates[k][2] = weight_lookup(cmake(-0.5,0.5)); gates[k][3] = weight_lookup(cmake(0.5,-0.5));
+    gates[k][0] = complex_lookup(0.5,-0.5); gates[k][1] = complex_lookup(0.5,-0.5);
+    gates[k][2] = complex_lookup(-0.5,0.5); gates[k][3] = complex_lookup(0.5,-0.5);
 
     qmdd_phase_gates_init(255);
 
@@ -164,13 +165,13 @@ qmdd_phase_gates_init(int n)
         cartesian = cmake_angle(angle, 1);
         gate_id = GATEID_Rk(k);
         gates[gate_id][0] = AADD_ONE;  gates[gate_id][1] = AADD_ZERO;
-        gates[gate_id][2] = AADD_ZERO; gates[gate_id][3] = weight_lookup(cartesian);
+        gates[gate_id][2] = AADD_ZERO; gates[gate_id][3] = weight_lookup(&cartesian);
 
         // backward rotation
         angle = -2*Pi / (fl_t)(1<<k);
         cartesian = cmake_angle(angle, 1);
         gate_id = GATEID_Rk_dag(k);
         gates[gate_id][0] = AADD_ONE;  gates[gate_id][1] = AADD_ZERO;
-        gates[gate_id][2] = AADD_ZERO; gates[gate_id][3] = weight_lookup(cartesian);
+        gates[gate_id][2] = AADD_ZERO; gates[gate_id][3] = weight_lookup(&cartesian);
     }
 }

--- a/src/qsylvan_simulator.c
+++ b/src/qsylvan_simulator.c
@@ -837,7 +837,7 @@ qmdd_measure_q0(QMDD qmdd, BDDVAR nvars, int *m, double *p)
     }
 
     // flip a coin
-    float rnd = ((float)rand())/RAND_MAX;
+    float rnd = ((float)rand())/((float)RAND_MAX);
     *m = (rnd < prob_low) ? 0 : 1;
     *p = prob_low;
 
@@ -904,7 +904,7 @@ qmdd_measure_all(QMDD qmdd, BDDVAR n, bool* ms, double *p)
         }
 
         // flip a coin
-        float rnd = ((float)rand())/RAND_MAX;
+        float rnd = ((float)rand())/((float)RAND_MAX);
         ms[k] = (rnd < prob_low) ? 0 : 1;
 
         // Get next edge
@@ -1005,7 +1005,7 @@ qmdd_amp_from_prob(double a)
     complex_t c;
     c.r = flt_sqrt(a);
     c.i = 0;
-    return weight_lookup(c);
+    return weight_lookup(&c);
 }
 
 /**********************</Measurements and probabilities>***********************/

--- a/src/sha2.c
+++ b/src/sha2.c
@@ -33,6 +33,7 @@
 
 #include <string.h>	/* memcpy()/memset() or bcopy()/bzero() */
 #include <assert.h>	/* assert() */
+#include <sys/param.h> /* for BYTE_ORDER */
 #include "sha2.h"
 
 /*

--- a/src/sha2.h
+++ b/src/sha2.h
@@ -47,6 +47,8 @@ extern "C" {
  */
 #include <sys/types.h>
 
+#define SHA2_USE_INTTYPES_H
+
 #ifdef SHA2_USE_INTTYPES_H
 
 #include <inttypes.h>

--- a/src/sylvan_align.h
+++ b/src/sylvan_align.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 Tom van Dijk, Formal Methods and Tools, University of Twente
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <sylvan_config.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if SYLVAN_USE_MMAP
+#include <sys/mman.h> // for mmap
+#endif
+
+#ifndef SYLVAN_ALIGN_H
+#define SYLVAN_ALIGN_H
+
+#ifdef __cplusplus
+namespace sylvan {
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+static inline void*
+alloc_aligned(size_t size)
+{ 
+    // make sure size is a multiple of LINE_SIZE
+    size = (size + LINE_SIZE - 1) & (~(LINE_SIZE - 1));
+    void* res;
+#if SYLVAN_USE_MMAP
+    res = mmap(0, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (res == MAP_FAILED) return 0;
+#else
+#if defined(_MSC_VER) || defined(__MINGW64_VERSION_MAJOR)
+    res = _aligned_malloc(size, LINE_SIZE);
+#elif defined(__MINGW32__)
+    res = __mingw_aligned_malloc(size, LINE_SIZE);
+#else
+    res = aligned_alloc(LINE_SIZE, size);
+#endif
+    if (res != 0) memset(res, 0, size);
+#endif
+    return res;
+}
+
+static inline void
+free_aligned(void* ptr, size_t size)
+{
+    // make sure size is a multiple of LINE_SIZE
+    size = (size + LINE_SIZE - 1) & (~(LINE_SIZE - 1));
+#if SYLVAN_USE_MMAP
+    munmap(ptr, size);
+#elif defined(_MSC_VER) || defined(__MINGW64_VERSION_MAJOR)
+    _aligned_free(ptr);
+#elif defined(__MINGW32__)
+    __mingw_aligned_free(ptr);
+#else
+    free(ptr);
+#endif
+    (void)size; // suppress unused parameter
+}
+
+static inline void
+clear_aligned(void* ptr, size_t size)
+{
+    // make sure size is a multiple of LINE_SIZE
+    size = (size + LINE_SIZE - 1) & (~(LINE_SIZE - 1));
+#if SYLVAN_USE_MMAP
+    // this is a trick to use mmap to try and reassign fresh zero'ed pages to the region
+    void* res = mmap(ptr, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+    if (res == MAP_FAILED) memset(ptr, 0, size);
+#else
+    memset(ptr, 0, size);
+#endif
+}
+
+#ifdef __cplusplus
+} /* namespace */
+#endif
+
+#endif

--- a/src/sylvan_config.h
+++ b/src/sylvan_config.h
@@ -24,6 +24,11 @@
 #define SYLVAN_STATS 0
 #endif
 
+/* Enable/disable using mmap to allocate large amounts of memory */
+#ifndef SYLVAN_USE_MMAP
+#define SYLVAN_USE_MMAP 0
+#endif
+
 /* Aggressive or conservative resizing strategy */
 #ifndef SYLVAN_AGGRESSIVE_RESIZE
 #define SYLVAN_AGGRESSIVE_RESIZE 1

--- a/src/sylvan_edge_weights.c
+++ b/src/sylvan_edge_weights.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdint.h>
 
 #include <sylvan_edge_weights.h>
 #include <sylvan_edge_weights_complex.h>
@@ -8,9 +9,12 @@
 void *wgt_storage; // TODO: move to source file?
 void *wgt_storage_new;
 
-AADD_WGT AADD_ONE;
 AADD_WGT AADD_ZERO;
+AADD_WGT AADD_ONE;
 AADD_WGT AADD_MIN_ONE;
+AADD_WGT AADD_IMG;
+AADD_WGT AADD_MIN_IMG;
+AADD_WGT AADD_SQRT_TWO;
 
 /**********************<Managing the edge weight table>************************/
 
@@ -26,28 +30,28 @@ void sylvan_edge_weights_free();
 /******************<Interface for different edge_weight_types>*****************/
 
 weight_t (*weight_malloc)();
-void (*_weight_value)(); // weight_value(WGT a, weight_type * res)
-AADD_WGT (*weight_lookup)(); // weight_lookup_(weight_type a)
-AADD_WGT (*_weight_lookup_ptr)(); // _weight_lookup_ptr(weight_type *a, void *wgt_store)
-void (*init_one_zero)();
+void (*_weight_value)(void *wgt_store, AADD_WGT a, weight_t res);
+AADD_WGT (*weight_lookup)(weight_t a);
+AADD_WGT (*_weight_lookup_ptr)(weight_t a, void *wgt_store);
+void (*init_one_zero)(void *wgt_store);
 
 /* Arithmetic operations on edge weights */
-void (*weight_abs)(); // a <-- |a|
-void (*weight_neg)(); // a <-- -a
-void (*weight_sqr)(); // a <-- a^2
-void (*weight_add)(); // a <-- a + b
-void (*weight_sub)(); // a <-- a - b
-void (*weight_mul)(); // a <-- a * b
-void (*weight_div)(); // a <-- a / b
-bool (*weight_eq)(); // returns true iff a == b
-bool (*weight_eps_close)(); // returns true iff dist(a,b) < eps
-bool (*weight_greater)(); // returns true iff a > b
+void (*weight_abs)(weight_t a); // a <-- |a|
+void (*weight_neg)(weight_t a); // a <-- -a
+void (*weight_sqr)(weight_t a); // a <-- a^2
+void (*weight_add)(weight_t a, weight_t b); // a <-- a + b
+void (*weight_sub)(weight_t a, weight_t b); // a <-- a - b
+void (*weight_mul)(weight_t a, weight_t b); // a <-- a * b
+void (*weight_div)(weight_t a, weight_t b); // a <-- a / b
+bool (*weight_eq)(weight_t a, weight_t b); // returns true iff a == b
+bool (*weight_eps_close)(weight_t a, weight_t b, double eps); // returns true iff dist(a,b) < eps
+bool (*weight_greater)(weight_t a, weight_t b); // returns true iff a > b
 
 /* Normalization methods */
-AADD_WGT (*wgt_norm_L2)(); // wgt_norm_L2(AADD_WGT *low, AADD_WGT *high)
-AADD_WGT (*wgt_get_low_L2normed)(); // wgt_get_low_L2normed(AADD_WGT high)
+AADD_WGT (*wgt_norm_L2)(AADD_WGT *low, AADD_WGT *high);
+AADD_WGT (*wgt_get_low_L2normed)(AADD_WGT high);
 
-void (*weight_fprint)(); // weight_fprint(FILE *stream, weight_t a)
+void (*weight_fprint)(FILE *stream, weight_t a);
 
 /**********************<Managing the edge weight table>************************/
 

--- a/src/sylvan_edge_weights.c
+++ b/src/sylvan_edge_weights.c
@@ -29,29 +29,27 @@ void sylvan_edge_weights_free();
 
 /******************<Interface for different edge_weight_types>*****************/
 
-weight_t (*weight_malloc)();
-void (*_weight_value)(void *wgt_store, AADD_WGT a, weight_t res);
-AADD_WGT (*weight_lookup)(weight_t a);
-AADD_WGT (*_weight_lookup_ptr)(weight_t a, void *wgt_store);
-void (*init_one_zero)(void *wgt_store);
+weight_malloc_f 		weight_malloc;
+_weight_value_f 		_weight_value;
 
-/* Arithmetic operations on edge weights */
-void (*weight_abs)(weight_t a); // a <-- |a|
-void (*weight_neg)(weight_t a); // a <-- -a
-void (*weight_sqr)(weight_t a); // a <-- a^2
-void (*weight_add)(weight_t a, weight_t b); // a <-- a + b
-void (*weight_sub)(weight_t a, weight_t b); // a <-- a - b
-void (*weight_mul)(weight_t a, weight_t b); // a <-- a * b
-void (*weight_div)(weight_t a, weight_t b); // a <-- a / b
-bool (*weight_eq)(weight_t a, weight_t b); // returns true iff a == b
-bool (*weight_eps_close)(weight_t a, weight_t b, double eps); // returns true iff dist(a,b) < eps
-bool (*weight_greater)(weight_t a, weight_t b); // returns true iff a > b
+weight_lookup_f 		weight_lookup;
+_weight_lookup_ptr_f	_weight_lookup_ptr;
+init_one_zero_f 		init_one_zero;
+weight_abs_f 			weight_abs;
+weight_neg_f 			weight_neg;
+weight_sqr_f 			weight_sqr;
+weight_add_f 			weight_add;
+weight_sub_f 			weight_sub;
+weight_mul_f 			weight_mul;
+weight_div_f 			weight_div;
+weight_eq_f 			weight_eq;
+weight_eps_close_f 		weight_eps_close;
+weight_greater_f		weight_greater;
 
-/* Normalization methods */
-AADD_WGT (*wgt_norm_L2)(AADD_WGT *low, AADD_WGT *high);
-AADD_WGT (*wgt_get_low_L2normed)(AADD_WGT high);
+wgt_norm_L2_f			wgt_norm_L2;
+wgt_get_low_L2normed_f	wgt_get_low_L2normed;
 
-void (*weight_fprint)(FILE *stream, weight_t a);
+weight_fprint_f 		weight_fprint;
 
 /**********************<Managing the edge weight table>************************/
 
@@ -73,24 +71,24 @@ void init_edge_weight_functions(edge_weight_type_t edge_weight_type)
     switch (edge_weight_type)
     {
     case WGT_COMPLEX_128:
-        weight_malloc       = &weight_complex_malloc;
-        _weight_value       = &_weight_complex_value;
-        weight_lookup       = &weight_complex_lookup;
-        _weight_lookup_ptr  = &_weight_complex_lookup_ptr;
-        init_one_zero       = &init_complex_one_zero;
-        weight_abs          = &weight_complex_abs;
-        weight_neg          = &weight_complex_neg;
-        weight_sqr          = &weight_complex_sqr;
-        weight_add          = &weight_complex_add;
-        weight_sub          = &weight_complex_sub;
-        weight_mul          = &weight_complex_mul;
-        weight_div          = &weight_complex_div;
-        weight_eq           = &weight_complex_eq;
-        weight_eps_close    = &weight_complex_eps_close;
-        weight_greater      = &weight_complex_greater;
-        wgt_norm_L2         = &wgt_complex_norm_L2;
-        wgt_get_low_L2normed= &wgt_complex_get_low_L2normed;
-        weight_fprint       = &weight_complex_fprint;
+        weight_malloc       = (weight_malloc_f) &weight_complex_malloc;
+        _weight_value       = (_weight_value_f) &_weight_complex_value;
+        weight_lookup       = (weight_lookup_f) &weight_complex_lookup;
+        _weight_lookup_ptr  = (_weight_lookup_ptr_f) &_weight_complex_lookup_ptr;
+        init_one_zero       = (init_one_zero_f) &init_complex_one_zero;
+        weight_abs          = (weight_abs_f) &weight_complex_abs;
+        weight_neg          = (weight_neg_f) &weight_complex_neg;
+        weight_sqr          = (weight_sqr_f) &weight_complex_sqr;
+        weight_add          = (weight_add_f) &weight_complex_add;
+        weight_sub          = (weight_sub_f) &weight_complex_sub;
+        weight_mul          = (weight_mul_f) &weight_complex_mul;
+        weight_div          = (weight_div_f) &weight_complex_div;
+        weight_eq           = (weight_eq_f) &weight_complex_eq;
+        weight_eps_close    = (weight_eps_close_f) &weight_complex_eps_close;
+        weight_greater      = (weight_greater_f) &weight_complex_greater;
+        wgt_norm_L2         = (wgt_norm_L2_f) &wgt_complex_norm_L2;
+        wgt_get_low_L2normed= (wgt_get_low_L2normed_f) &wgt_complex_get_low_L2normed;
+        weight_fprint       = (weight_fprint_f) &weight_complex_fprint;
         break;
     default:
         printf("ERROR: Unrecognized weight type = %d\n", edge_weight_type);

--- a/src/sylvan_edge_weights.h
+++ b/src/sylvan_edge_weights.h
@@ -11,7 +11,7 @@ extern AADD_WGT AADD_ONE;
 extern AADD_WGT AADD_ZERO;
 extern AADD_WGT AADD_MIN_ONE;
 
-typedef void* weight_t;
+typedef complex_t *weight_t;
 
 typedef enum edge_weight_type {
     WGT_DOUBLE,
@@ -62,32 +62,32 @@ extern AADD_WGT wgt_table_gc_keep(AADD_WGT a);
 /******************<Interface for different edge_weight_types>*****************/
 
 extern weight_t (*weight_malloc)();
-extern void (*_weight_value)(); // weight_value(WGT a, weight_type * res)
-extern AADD_WGT (*weight_lookup)(); // weight_lookup_(weight_type a)
-extern AADD_WGT (*_weight_lookup_ptr)(); // _weight_lookup_ptr(weight_type *a, void *wgt_store)
+extern void (*_weight_value)(void *wgt_store, AADD_WGT a, weight_t res);
+extern AADD_WGT (*weight_lookup)(weight_t a);
+extern AADD_WGT (*_weight_lookup_ptr)(weight_t a, void *wgt_store);
 #define weight_lookup_ptr(a) _weight_lookup_ptr(a, wgt_storage)
 #define weight_value(a, res) _weight_value(wgt_storage, a, res)
 
-extern void (*init_one_zero)();
+extern void (*init_one_zero)(void *wgt_store);
 
 /* Arithmetic operations on edge weights */
-extern void (*weight_abs)(); // a <-- |a|
-extern void (*weight_neg)(); // a <-- -a
-extern void (*weight_sqr)(); // a <-- a^2
-extern void (*weight_add)(); // a <-- a + b
-extern void (*weight_sub)(); // a <-- a - b
-extern void (*weight_mul)(); // a <-- a * b
-extern void (*weight_div)(); // a <-- a / b
-extern bool (*weight_eq)(); // returns true iff a == b
-extern bool (*weight_eps_close)(); // returns true iff dist(a,b) < eps
+extern void (*weight_abs)(weight_t a); // a <-- |a|
+extern void (*weight_neg)(weight_t a); // a <-- -a
+extern void (*weight_sqr)(weight_t a); // a <-- a^2
+extern void (*weight_add)(weight_t a, weight_t b); // a <-- a + b
+extern void (*weight_sub)(weight_t a, weight_t b); // a <-- a - b
+extern void (*weight_mul)(weight_t a, weight_t b); // a <-- a * b
+extern void (*weight_div)(weight_t a, weight_t b); // a <-- a / b
+extern bool (*weight_eq)(weight_t a, weight_t b); // returns true iff a == b
+extern bool (*weight_eps_close)(weight_t a, weight_t b, double eps); // returns true iff dist(a,b) < eps
 #define weight_approx_eq(a,b) weight_eps_close(a,b,sylvan_edge_weights_tolerance())
-extern bool (*weight_greater)(); // returns true iff a > b
+extern bool (*weight_greater)(weight_t a, weight_t b); // returns true iff a > b
 
 /* Normalization methods */
-extern AADD_WGT (*wgt_norm_L2)(); // wgt_norm_L2(AADD_WGT *low, AADD_WGT *high)
-extern AADD_WGT (*wgt_get_low_L2normed)(); // wgt_get_low_L2normed(AADD_WGT high)
+extern AADD_WGT (*wgt_norm_L2)(AADD_WGT *low, AADD_WGT *high);
+extern AADD_WGT (*wgt_get_low_L2normed)(AADD_WGT high);
 
-extern void (*weight_fprint)(); // weight_fprint(FILE *stream, weight_t a)
+extern void (*weight_fprint)(FILE *stream, weight_t a);
 
 /*****************</Interface for different edge_weight_types>*****************/
 

--- a/src/sylvan_edge_weights.h
+++ b/src/sylvan_edge_weights.h
@@ -11,7 +11,7 @@ extern AADD_WGT AADD_ONE;
 extern AADD_WGT AADD_ZERO;
 extern AADD_WGT AADD_MIN_ONE;
 
-typedef complex_t *weight_t;
+typedef void *weight_t;
 
 typedef enum edge_weight_type {
     WGT_DOUBLE,
@@ -61,33 +61,59 @@ extern AADD_WGT wgt_table_gc_keep(AADD_WGT a);
 
 /******************<Interface for different edge_weight_types>*****************/
 
-extern weight_t (*weight_malloc)();
-extern void (*_weight_value)(void *wgt_store, AADD_WGT a, weight_t res);
-extern AADD_WGT (*weight_lookup)(weight_t a);
-extern AADD_WGT (*_weight_lookup_ptr)(weight_t a, void *wgt_store);
-#define weight_lookup_ptr(a) _weight_lookup_ptr(a, wgt_storage)
-#define weight_value(a, res) _weight_value(wgt_storage, a, res)
+typedef weight_t (*weight_malloc_f)();
+typedef void (*_weight_value_f)(void *wgt_store, AADD_WGT a, weight_t res);
+typedef AADD_WGT (*weight_lookup_f)(weight_t a);
+typedef AADD_WGT (*_weight_lookup_ptr_f)(weight_t a, void *wgt_store);
 
-extern void (*init_one_zero)(void *wgt_store);
+typedef void (*init_one_zero_f)(void *wgt_store);
 
 /* Arithmetic operations on edge weights */
-extern void (*weight_abs)(weight_t a); // a <-- |a|
-extern void (*weight_neg)(weight_t a); // a <-- -a
-extern void (*weight_sqr)(weight_t a); // a <-- a^2
-extern void (*weight_add)(weight_t a, weight_t b); // a <-- a + b
-extern void (*weight_sub)(weight_t a, weight_t b); // a <-- a - b
-extern void (*weight_mul)(weight_t a, weight_t b); // a <-- a * b
-extern void (*weight_div)(weight_t a, weight_t b); // a <-- a / b
-extern bool (*weight_eq)(weight_t a, weight_t b); // returns true iff a == b
-extern bool (*weight_eps_close)(weight_t a, weight_t b, double eps); // returns true iff dist(a,b) < eps
-#define weight_approx_eq(a,b) weight_eps_close(a,b,sylvan_edge_weights_tolerance())
-extern bool (*weight_greater)(weight_t a, weight_t b); // returns true iff a > b
+typedef void (*weight_abs_f)(weight_t a); // a <-- |a|
+typedef void (*weight_neg_f)(weight_t a); // a <-- -a
+typedef void (*weight_sqr_f)(weight_t a); // a <-- a^2
+typedef void (*weight_add_f)(weight_t a, weight_t b); // a <-- a + b
+typedef void (*weight_sub_f)(weight_t a, weight_t b); // a <-- a - b
+typedef void (*weight_mul_f)(weight_t a, weight_t b); // a <-- a * b
+typedef void (*weight_div_f)(weight_t a, weight_t b); // a <-- a / b
+typedef bool (*weight_eq_f)(weight_t a, weight_t b); // returns true iff a == b
+typedef bool (*weight_eps_close_f)(weight_t a, weight_t b, double eps); // returns true iff dist(a,b) < eps
+typedef bool (*weight_greater_f)(weight_t a, weight_t b); // returns true iff a > b
 
 /* Normalization methods */
-extern AADD_WGT (*wgt_norm_L2)(AADD_WGT *low, AADD_WGT *high);
-extern AADD_WGT (*wgt_get_low_L2normed)(AADD_WGT high);
+typedef AADD_WGT (*wgt_norm_L2_f)(AADD_WGT *low, AADD_WGT *high);
+typedef AADD_WGT (*wgt_get_low_L2normed_f)(AADD_WGT high);
 
-extern void (*weight_fprint)(FILE *stream, weight_t a);
+typedef void (*weight_fprint_f)(FILE *stream, weight_t a);
+
+
+
+extern weight_malloc_f 		weight_malloc;
+extern _weight_value_f 		_weight_value;
+
+extern weight_lookup_f 		weight_lookup;
+extern _weight_lookup_ptr_f	_weight_lookup_ptr;
+extern init_one_zero_f 		init_one_zero;
+extern weight_abs_f 		weight_abs;
+extern weight_neg_f 		weight_neg;
+extern weight_sqr_f 		weight_sqr;
+extern weight_add_f 		weight_add;
+extern weight_sub_f 		weight_sub;
+extern weight_mul_f 		weight_mul;
+extern weight_div_f 		weight_div;
+extern weight_eq_f 			weight_eq;
+extern weight_eps_close_f 	weight_eps_close;
+extern weight_greater_f		weight_greater;
+
+extern wgt_norm_L2_f		wgt_norm_L2;
+extern wgt_get_low_L2normed_f		wgt_get_low_L2normed;
+
+extern weight_fprint_f 		weight_fprint;
+
+
+#define weight_lookup_ptr(a) _weight_lookup_ptr(a, wgt_storage)
+#define weight_value(a, res) _weight_value(wgt_storage, a, res)
+#define weight_approx_eq(a,b) weight_eps_close(a,b,sylvan_edge_weights_tolerance())
 
 /*****************</Interface for different edge_weight_types>*****************/
 

--- a/src/sylvan_edge_weights_complex.c
+++ b/src/sylvan_edge_weights_complex.c
@@ -26,10 +26,10 @@ comp_cart_to_polar(fl_t r, fl_t i, fl_t *magnitude, fl_t *angle)
 
 /*****************<Implementation of edge_weights interface>*******************/
 
-weight_t
+complex_t *
 weight_complex_malloc()
 {
-    weight_t res = malloc(sizeof(complex_t));
+    complex_t *res = malloc(sizeof(complex_t));
     return res;
 }
 
@@ -67,9 +67,9 @@ _weight_complex_lookup_ptr(complex_t *a, void *wgt_store)
 }
 
 AADD_WGT
-weight_complex_lookup(complex_t a)
+weight_complex_lookup(complex_t *a)
 {
-    return _weight_complex_lookup_ptr(&a, wgt_storage);
+    return _weight_complex_lookup_ptr(a, wgt_storage);
 }
 
 void
@@ -203,9 +203,9 @@ wgt_complex_norm_L2(AADD_WGT *low, AADD_WGT *high)
     complex_t c_norm = cmake_angle(theta_a, _norm);
 
     // return
-    *low  = weight_complex_lookup(a);
-    *high = weight_complex_lookup(b);
-    return weight_complex_lookup(c_norm);   
+    *low  = weight_complex_lookup(&a);
+    *high = weight_complex_lookup(&b);
+    return weight_complex_lookup(&c_norm);
 }
 
 AADD_WGT
@@ -231,7 +231,8 @@ wgt_complex_get_low_L2normed(AADD_WGT high)
     }
     fl_t a = flt_sqrt(1.0 - mag_b);
 
-    return weight_complex_lookup(cmake(a, 0));
+    complex_t c = cmake(a, 0);
+    return weight_complex_lookup(&c);
 }
 
 void

--- a/src/sylvan_edge_weights_complex.h
+++ b/src/sylvan_edge_weights_complex.h
@@ -7,9 +7,9 @@
 
 /******************<Implementation of edge_weights interface>******************/
 
-weight_t weight_complex_malloc();
+complex_t *weight_complex_malloc();
 void _weight_complex_value(void *wgt_store, AADD_WGT a, complex_t *res);
-AADD_WGT weight_complex_lookup(complex_t a);
+AADD_WGT weight_complex_lookup(complex_t *a);
 AADD_WGT _weight_complex_lookup_ptr(complex_t *a, void *wgt_store);
 
 void init_complex_one_zero(void *wgt_store);
@@ -29,6 +29,21 @@ AADD_WGT wgt_complex_norm_L2(AADD_WGT *low, AADD_WGT *high);
 AADD_WGT wgt_complex_get_low_L2normed(AADD_WGT high);
 
 void weight_complex_fprint(FILE *stream, complex_t *a);
+
+
+static inline AADD_WGT
+complex_lookup_angle(fl_t theta, fl_t mag)
+{
+	complex_t c = cmake_angle(theta, mag);
+	return weight_lookup(&c);
+}
+
+static inline AADD_WGT
+complex_lookup(fl_t r, fl_t i)
+{
+	complex_t c = cmake(r, i);
+	return weight_lookup(&c);
+}
 
 /*****************</Implementation of edge_weights interface>******************/
 

--- a/src/sylvan_ldd.c
+++ b/src/sylvan_ldd.c
@@ -2449,7 +2449,7 @@ static avl_node_t *lddmc_ser_set = NULL;
 static avl_node_t *lddmc_ser_reversed_set = NULL;
 
 // Start counting (assigning numbers to MDDs) at 2
-static volatile size_t lddmc_ser_counter = 2;
+static size_t lddmc_ser_counter = 2;
 static size_t lddmc_ser_done = 0;
 
 // Given a MDD, assign unique numbers to all nodes

--- a/src/sylvan_ldd.c
+++ b/src/sylvan_ldd.c
@@ -1848,7 +1848,7 @@ lddmc_member_cube(MDD a, uint32_t* values, size_t count)
     while (1) {
         if (a == lddmc_false) return 0;
         if (a == lddmc_true) return 1;
-        assert(count > 0); // size mismatch
+        if (count <= 0) assert(count > 0); // size mismatch
 
         a = lddmc_follow(a, *values);
         values++;
@@ -1862,7 +1862,7 @@ lddmc_member_cube_copy(MDD a, uint32_t* values, int* copy, size_t count)
     while (1) {
         if (a == lddmc_false) return 0;
         if (a == lddmc_true) return 1;
-        assert(count > 0); // size mismatch
+        if (count <= 0) assert(count > 0); // size mismatch
 
         if (*copy) a = lddmc_followcopy(a);
         else a = lddmc_follow(a, *values);

--- a/src/sylvan_refs.h
+++ b/src/sylvan_refs.h
@@ -31,15 +31,15 @@ extern "C" {
  */
 typedef struct
 {
-    uint64_t *refs_table;           // table itself
-    size_t refs_size;               // number of buckets
+    _Atomic(uint64_t) *refs_table;        // table itself
+    size_t refs_size;                     // number of buckets
 
     /* helpers during resize operation */
-    volatile uint32_t refs_control; // control field
-    uint64_t *refs_resize_table;    // previous table
-    size_t refs_resize_size;        // size of previous table
-    size_t refs_resize_part;        // which part is next
-    size_t refs_resize_done;        // how many parts are done
+    _Atomic(uint32_t) refs_control;       // control field
+    _Atomic(uint64_t) *refs_resize_table; // previous table
+    size_t refs_resize_size;              // size of previous table
+    _Atomic(size_t) refs_resize_part;     // which part is next
+    _Atomic(size_t) refs_resize_done;     // how many parts are done
 } refs_table_t;
 
 // Count number of unique entries (not number of references)

--- a/src/sylvan_sl.c
+++ b/src/sylvan_sl.c
@@ -15,9 +15,8 @@
  */
 
 #include <sylvan.h>
+#include <sylvan_align.h>
 #include <sylvan_sl.h>
-
-#include <sys/mman.h> // for mmap, munmap, etc
 
 /* A SL_DEPTH of 6 means 32 bytes per bucket, of 14 means 64 bytes per bucket.
    However, there is a very large performance drop with only 6 levels. */
@@ -26,23 +25,15 @@
 typedef struct
 {
     BDD dd;
-    uint32_t next[SL_DEPTH];
+    _Atomic(uint32_t) next[SL_DEPTH];
 } sl_bucket;
 
 struct sylvan_skiplist
 {
     sl_bucket *buckets;
     size_t size;
-    size_t next;
+    _Atomic(size_t) next;
 };
-
-#ifndef cas
-#define cas(ptr, old, new) (__sync_bool_compare_and_swap((ptr),(old),(new)))
-#endif
-
-#ifndef compiler_barrier
-#define compiler_barrier() { asm volatile("" ::: "memory"); }
-#endif
 
 sylvan_skiplist_t
 sylvan_skiplist_alloc(size_t size)
@@ -52,8 +43,8 @@ sylvan_skiplist_alloc(size_t size)
         exit(1);
     }
     sylvan_skiplist_t l = malloc(sizeof(struct sylvan_skiplist));
-    l->buckets = (sl_bucket*)mmap(0, sizeof(sl_bucket)*size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, 0, 0);
-    if (l->buckets == (sl_bucket*)-1) {
+    l->buckets = alloc_aligned(sizeof(sl_bucket) * size);
+    if (l->buckets == 0) {
         fprintf(stderr, "sylvan: Unable to allocate virtual memory (%'zu bytes) for the skiplist!\n", size*sizeof(sl_bucket));
         exit(1);
     }
@@ -65,7 +56,7 @@ sylvan_skiplist_alloc(size_t size)
 void
 sylvan_skiplist_free(sylvan_skiplist_t l)
 {
-    munmap(l->buckets, sizeof(sl_bucket)*l->size);
+    free_aligned(l->buckets, sizeof(sl_bucket)*l->size);
     free(l);
 }
 
@@ -83,7 +74,7 @@ sylvan_skiplist_get(sylvan_skiplist_t l, MTBDD dd)
         /* invariant: [loc].dd < dd */
         /* note: this is always true for loc==0 */
         sl_bucket *e = l->buckets + loc;
-        uint32_t loc_next = (*(volatile uint32_t*)&e->next[k]) & 0x7fffffff;
+        uint32_t loc_next = atomic_load_explicit(e->next+k, memory_order_acquire) & 0x7fffffff;
         if (loc_next != 0 && l->buckets[loc_next].dd == dd) {
             /* found */
             return loc_next;
@@ -109,7 +100,7 @@ VOID_TASK_IMPL_2(sylvan_skiplist_assign_next, sylvan_skiplist_t, l, MTBDD, dd)
         /* invariant: [loc].dd < dd */
         /* note: this is always true for loc==0 */
         sl_bucket *e = l->buckets + loc;
-        loc_next = (*(volatile uint32_t*)&e->next[k]) & 0x7fffffff;
+        loc_next = atomic_load_explicit(e->next+k, memory_order_acquire) & 0x7fffffff;
         if (loc_next != 0 && l->buckets[loc_next].dd == dd) {
             /* found */
             return;
@@ -120,14 +111,15 @@ VOID_TASK_IMPL_2(sylvan_skiplist_assign_next, sylvan_skiplist_t, l, MTBDD, dd)
             /* go down */
             trace[k] = loc;
             k--;
-        } else if (!(e->next[0] & 0x80000000) && cas(&e->next[0], loc_next, loc_next|0x80000000)) {
+        } else if (!(e->next[0] & 0x80000000) &&
+                   atomic_compare_exchange_strong(&e->next[0], &loc_next, loc_next|0x80000000)) {
             /* locked */
             break;
         }
     }
 
     /* claim next item */
-    const uint64_t next = __sync_fetch_and_add(&l->next, 1);
+    const uint64_t next = atomic_fetch_add(&l->next, 1);
     if (next >= l->size) {
         fprintf(stderr, "Out of cheese exception, no more blocks available\n");
         exit(1);
@@ -137,8 +129,7 @@ VOID_TASK_IMPL_2(sylvan_skiplist_assign_next, sylvan_skiplist_t, l, MTBDD, dd)
     sl_bucket *a = l->buckets + next;
     a->dd = dd;
     a->next[0] = loc_next;
-    compiler_barrier();
-    l->buckets[loc].next[0] = next;
+    atomic_store_explicit(l->buckets[loc].next, next, memory_order_release);
 
     /* determine height */
     uint64_t h = 1 + __builtin_clz(LACE_TRNG) / 2;
@@ -150,12 +141,12 @@ VOID_TASK_IMPL_2(sylvan_skiplist_assign_next, sylvan_skiplist_t, l, MTBDD, dd)
         for (;;) {
             sl_bucket *e = l->buckets + loc;
             /* note, at k>0, no locks on edges */
-            uint32_t loc_next = *(volatile uint32_t*)&e->next[k];
+            uint32_t loc_next = atomic_load_explicit(&e->next[k], memory_order_acquire);
             if (loc_next != 0 && l->buckets[loc_next].dd < dd) {
                 loc = loc_next;
             } else {
                 a->next[k] = loc_next;
-                if (cas(&e->next[k], loc_next, next)) break;
+                if (atomic_compare_exchange_strong(&e->next[k], &loc_next, next)) break;
             }
         }
     }

--- a/src/sylvan_table.c
+++ b/src/sylvan_table.c
@@ -16,18 +16,10 @@
  */
 
 #include <sylvan_int.h>
+#include <sylvan_align.h>
 
 #include <errno.h>  // for errno
 #include <string.h> // memset
-#include <sys/mman.h> // for mmap
-
-#ifndef MAP_ANONYMOUS
-#define MAP_ANONYMOUS MAP_ANON
-#endif
-
-#ifndef cas
-#define cas(ptr, old, new) (__sync_bool_compare_and_swap((ptr),(old),(new)))
-#endif
 
 DECLARE_THREAD_LOCAL(my_region, uint64_t);
 
@@ -46,10 +38,10 @@ claim_data_bucket(const llmsset_t dbs)
     for (;;) {
         if (my_region != (uint64_t)-1) {
             // find empty bucket in region <my_region>
-            uint64_t *ptr = dbs->bitmap2 + (my_region*8);
+            _Atomic(uint64_t)* ptr = dbs->bitmap2 + (my_region*8);
             int i=0;
             for (;i<8;) {
-                uint64_t v = *ptr;
+                uint64_t v = atomic_load_explicit(ptr, memory_order_relaxed);
                 if (v != 0xffffffffffffffffLL) {
                     int j = __builtin_clzll(~v);
                     *ptr |= (0x8000000000000000LL>>j);
@@ -71,13 +63,13 @@ claim_data_bucket(const llmsset_t dbs)
             if (my_region >= (dbs->table_size/(64*8))) my_region = 0;
 
             // try to claim it
-            uint64_t *ptr = dbs->bitmap1 + (my_region/64);
+            _Atomic(uint64_t)* ptr = dbs->bitmap1 + (my_region/64);
             uint64_t mask = 0x8000000000000000LL >> (my_region&63);
             uint64_t v;
 restart:
-            v = *ptr;
+            v = atomic_load_explicit(ptr, memory_order_relaxed);
             if (v & mask) continue; // taken
-            if (cas(ptr, v, v|mask)) break;
+            if (atomic_compare_exchange_weak(ptr, &v, v|mask)) break;
             else goto restart;
         }
         SET_THREAD_LOCAL(my_region, my_region);
@@ -87,9 +79,9 @@ restart:
 static void
 release_data_bucket(const llmsset_t dbs, uint64_t index)
 {
-    uint64_t *ptr = dbs->bitmap2 + (index/64);
+    _Atomic(uint64_t)* ptr = dbs->bitmap2 + (index/64);
     uint64_t mask = 0x8000000000000000LL >> (index&63);
-    *ptr &= ~mask;
+    atomic_fetch_and(ptr, ~mask);
 }
 
 static void
@@ -140,8 +132,8 @@ llmsset_lookup2(const llmsset_t dbs, uint64_t a, uint64_t b, int* created, const
 #endif
 
     for (;;) {
-        volatile uint64_t *bucket = dbs->table + idx;
-        uint64_t v = *bucket;
+        _Atomic(uint64_t)* bucket = dbs->table + idx;
+        uint64_t v = atomic_load_explicit(bucket, memory_order_acquire);
 
         if (v == 0) {
             if (cidx == 0) {
@@ -153,12 +145,10 @@ llmsset_lookup2(const llmsset_t dbs, uint64_t a, uint64_t b, int* created, const
                 d_ptr[0] = a;
                 d_ptr[1] = b;
             }
-            if (cas(bucket, 0, hash | cidx)) {
+            if (atomic_compare_exchange_strong(bucket, &v, hash | cidx)) {
                 if (custom) set_custom_bucket(dbs, cidx, custom);
                 *created = 1;
                 return cidx;
-            } else {
-                v = *bucket;
             }
         }
 
@@ -237,16 +227,17 @@ llmsset_rehash_bucket(const llmsset_t dbs, uint64_t d_idx)
 #endif
 
     for (;;) {
-        volatile uint64_t *bucket = &dbs->table[idx];
-        if (*bucket == 0 && cas(bucket, 0, new_v)) return 1;
+        _Atomic(uint64_t)* bucket = &dbs->table[idx];
+        uint64_t v = atomic_load_explicit(bucket, memory_order_acquire);
+        if (v == 0 && atomic_compare_exchange_strong(bucket, &v, new_v)) return 1;
 
         // find next idx on probe sequence
         idx = (idx & CL_MASK) | ((idx+1) & CL_MASK_R);
         if (idx == last) {
-            if (++i == *(volatile int16_t*)&dbs->threshold) {
+            if (++i == atomic_load_explicit(&dbs->threshold, memory_order_relaxed)) {
                 // failed to find empty spot in probe sequence
                 // solution: increase probe sequence length...
-                __sync_fetch_and_add(&dbs->threshold, 1);
+                atomic_fetch_add(&dbs->threshold, 1);
             }
 
             // go to next cache line in probe sequence
@@ -264,9 +255,9 @@ llmsset_rehash_bucket(const llmsset_t dbs, uint64_t d_idx)
 llmsset_t
 llmsset_create(size_t initial_size, size_t max_size)
 {
-    llmsset_t dbs = NULL;
-    if (posix_memalign((void**)&dbs, LINE_SIZE, sizeof(struct llmsset)) != 0) {
-        fprintf(stderr, "llmsset_create: Unable to allocate memory!\n");
+    llmsset_t dbs = alloc_aligned(sizeof(struct llmsset));
+    if (dbs == 0) {
+        fprintf(stderr, "llmsset_create: Unable to allocate memory: %s!\n", strerror(errno));
         exit(1);
     }
 
@@ -301,19 +292,19 @@ llmsset_create(size_t initial_size, size_t max_size)
     /* This implementation of "resizable hash table" allocates the max_size table in virtual memory,
        but only uses the "actual size" part in real memory */
 
-    dbs->table = (uint64_t*)mmap(0, dbs->max_size * 8, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    dbs->data = (uint8_t*)mmap(0, dbs->max_size * 16, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    dbs->table = (_Atomic(uint64_t)*) alloc_aligned(dbs->max_size * 8);
+    dbs->data = (uint8_t*) alloc_aligned(dbs->max_size * 16);
 
     /* Also allocate bitmaps. Each region is 64*8 = 512 buckets.
        Overhead of bitmap1: 1 bit per 4096 bucket.
        Overhead of bitmap2: 1 bit per bucket.
        Overhead of bitmapc: 1 bit per bucket. */
 
-    dbs->bitmap1 = (uint64_t*)mmap(0, dbs->max_size / (512*8), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    dbs->bitmap2 = (uint64_t*)mmap(0, dbs->max_size / 8, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    dbs->bitmapc = (uint64_t*)mmap(0, dbs->max_size / 8, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    dbs->bitmap1 = (_Atomic(uint64_t)*)alloc_aligned(dbs->max_size / (512*8));
+    dbs->bitmap2 = (_Atomic(uint64_t)*)alloc_aligned(dbs->max_size / 8);
+    dbs->bitmapc = (uint64_t*)alloc_aligned(dbs->max_size / 8);
 
-    if (dbs->table == (uint64_t*)-1 || dbs->data == (uint8_t*)-1 || dbs->bitmap1 == (uint64_t*)-1 || dbs->bitmap2 == (uint64_t*)-1 || dbs->bitmapc == (uint64_t*)-1) {
+    if (dbs->table == 0 || dbs->data == 0 || dbs->bitmap1 == 0 || dbs->bitmap2 == 0 || dbs->bitmapc == 0) {
         fprintf(stderr, "llmsset_create: Unable to allocate memory: %s!\n", strerror(errno));
         exit(1);
     }
@@ -346,12 +337,12 @@ llmsset_create(size_t initial_size, size_t max_size)
 void
 llmsset_free(llmsset_t dbs)
 {
-    munmap(dbs->table, dbs->max_size * 8);
-    munmap(dbs->data, dbs->max_size * 16);
-    munmap(dbs->bitmap1, dbs->max_size / (512*8));
-    munmap(dbs->bitmap2, dbs->max_size / 8);
-    munmap(dbs->bitmapc, dbs->max_size / 8);
-    free(dbs);
+    free_aligned(dbs->table, dbs->max_size * 8);
+    free_aligned(dbs->data, dbs->max_size * 16);
+    free_aligned(dbs->bitmap1, dbs->max_size / (512*8));
+    free_aligned(dbs->bitmap2, dbs->max_size / 8);
+    free_aligned(dbs->bitmapc, dbs->max_size / 8);
+    free_aligned(dbs, sizeof(struct llmsset));
 }
 
 VOID_TASK_IMPL_1(llmsset_clear, llmsset_t, dbs)
@@ -362,15 +353,8 @@ VOID_TASK_IMPL_1(llmsset_clear, llmsset_t, dbs)
 
 VOID_TASK_IMPL_1(llmsset_clear_data, llmsset_t, dbs)
 {
-    if (mmap(dbs->bitmap1, dbs->max_size / (512*8), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0) != (void*)-1) {
-    } else {
-        memset(dbs->bitmap1, 0, dbs->max_size / (512*8));
-    }
-
-    if (mmap(dbs->bitmap2, dbs->max_size / 8, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0) != (void*)-1) {
-    } else {
-        memset(dbs->bitmap2, 0, dbs->max_size / 8);
-    }
+    clear_aligned(dbs->bitmap1, dbs->max_size / (512*8));
+    clear_aligned(dbs->bitmap2, dbs->max_size / 8);
 
     // forbid first two positions (index 0 and 1)
     dbs->bitmap2[0] = 0xc000000000000000LL;
@@ -380,34 +364,26 @@ VOID_TASK_IMPL_1(llmsset_clear_data, llmsset_t, dbs)
 
 VOID_TASK_IMPL_1(llmsset_clear_hashes, llmsset_t, dbs)
 {
-    // just reallocate...
-    if (mmap(dbs->table, dbs->max_size * 8, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0) != (void*)-1) {
-#if defined(madvise) && defined(MADV_RANDOM)
-        madvise(dbs->table, sizeof(uint64_t[dbs->max_size]), MADV_RANDOM);
-#endif
-    } else {
-        // reallocate failed... expensive fallback
-        memset(dbs->table, 0, dbs->max_size * 8);
-    }
+    clear_aligned(dbs->table, dbs->max_size * 8);
 }
 
 int
 llmsset_is_marked(const llmsset_t dbs, uint64_t index)
 {
-    volatile uint64_t *ptr = dbs->bitmap2 + (index/64);
+    _Atomic(uint64_t)* ptr = dbs->bitmap2 + (index/64);
     uint64_t mask = 0x8000000000000000LL >> (index&63);
-    return (*ptr & mask) ? 1 : 0;
+    return (atomic_load_explicit(ptr, memory_order_relaxed) & mask) ? 1 : 0;
 }
 
 int
 llmsset_mark(const llmsset_t dbs, uint64_t index)
 {
-    volatile uint64_t *ptr = dbs->bitmap2 + (index/64);
+    _Atomic(uint64_t)* ptr = dbs->bitmap2 + (index/64);
     uint64_t mask = 0x8000000000000000LL >> (index&63);
     for (;;) {
         uint64_t v = *ptr;
         if (v & mask) return 0;
-        if (cas(ptr, v, v|mask)) return 1;
+        if (atomic_compare_exchange_weak(ptr, &v, v|mask)) return 1;
     }
 }
 
@@ -419,10 +395,10 @@ TASK_3(int, llmsset_rehash_par, llmsset_t, dbs, size_t, first, size_t, count)
         return bad + SYNC(llmsset_rehash_par);
     } else {
         int bad = 0;
-        uint64_t *ptr = dbs->bitmap2 + (first / 64);
+        _Atomic(uint64_t)* ptr = dbs->bitmap2 + (first / 64);
         uint64_t mask = 0x8000000000000000LL >> (first & 63);
         for (size_t k=0; k<count; k++) {
-            if (*ptr & mask) {
+            if (atomic_load_explicit(ptr, memory_order_relaxed) & mask) {
                 if (llmsset_rehash_bucket(dbs, first+k) == 0) bad++;
             }
             mask >>= 1;
@@ -450,20 +426,20 @@ TASK_3(size_t, llmsset_count_marked_par, llmsset_t, dbs, size_t, first, size_t, 
         return left + right;
     } else {
         size_t result = 0;
-        uint64_t *ptr = dbs->bitmap2 + (first / 64);
+        _Atomic(uint64_t)* ptr = dbs->bitmap2 + (first / 64);
         if (count == 512) {
-            result += __builtin_popcountll(ptr[0]);
-            result += __builtin_popcountll(ptr[1]);
-            result += __builtin_popcountll(ptr[2]);
-            result += __builtin_popcountll(ptr[3]);
-            result += __builtin_popcountll(ptr[4]);
-            result += __builtin_popcountll(ptr[5]);
-            result += __builtin_popcountll(ptr[6]);
-            result += __builtin_popcountll(ptr[7]);
+            result += __builtin_popcountll(atomic_load_explicit(ptr+0, memory_order_relaxed));
+            result += __builtin_popcountll(atomic_load_explicit(ptr+1, memory_order_relaxed));
+            result += __builtin_popcountll(atomic_load_explicit(ptr+2, memory_order_relaxed));
+            result += __builtin_popcountll(atomic_load_explicit(ptr+3, memory_order_relaxed));
+            result += __builtin_popcountll(atomic_load_explicit(ptr+4, memory_order_relaxed));
+            result += __builtin_popcountll(atomic_load_explicit(ptr+5, memory_order_relaxed));
+            result += __builtin_popcountll(atomic_load_explicit(ptr+6, memory_order_relaxed));
+            result += __builtin_popcountll(atomic_load_explicit(ptr+7, memory_order_relaxed));
         } else {
             uint64_t mask = 0x8000000000000000LL >> (first & 63);
             for (size_t k=0; k<count; k++) {
-                if (*ptr & mask) result += 1;
+                if (atomic_load_explicit(ptr, memory_order_relaxed) & mask) result += 1;
                 mask >>= 1;
                 if (mask == 0) {
                     ptr++;
@@ -489,8 +465,8 @@ VOID_TASK_3(llmsset_destroy_par, llmsset_t, dbs, size_t, first, size_t, count)
         SYNC(llmsset_destroy_par);
     } else {
         for (size_t k=first; k<first+count; k++) {
-            volatile uint64_t *ptr2 = dbs->bitmap2 + (k/64);
-            volatile uint64_t *ptrc = dbs->bitmapc + (k/64);
+            _Atomic(uint64_t)* ptr2 = dbs->bitmap2 + (k/64);
+            uint64_t *ptrc = dbs->bitmapc + (k/64);
             uint64_t mask = 0x8000000000000000LL >> (k&63);
 
             // if not marked but is custom

--- a/src/sylvan_table.h
+++ b/src/sylvan_table.h
@@ -51,22 +51,22 @@ typedef void (*llmsset_destroy_cb)(uint64_t, uint64_t);
 
 typedef struct llmsset
 {
-    uint64_t          *table;       // table with hashes
-    uint8_t           *data;        // table with values
-    uint64_t          *bitmap1;     // ownership bitmap (per 512 buckets)
-    uint64_t          *bitmap2;     // bitmap for "contains data"
-    uint64_t          *bitmapc;     // bitmap for "use custom functions"
-    size_t            max_size;     // maximum size of the hash table (for resizing)
-    size_t            table_size;   // size of the hash table (number of slots) --> power of 2!
+    _Atomic(uint64_t)* table;        // table with hashes
+    uint8_t*           data;         // table with values
+    _Atomic(uint64_t)* bitmap1;      // ownership bitmap (per 512 buckets)
+    _Atomic(uint64_t)* bitmap2;      // bitmap for "contains data"
+    uint64_t*          bitmapc;      // bitmap for "use custom functions"
+    size_t             max_size;     // maximum size of the hash table (for resizing)
+    size_t             table_size;   // size of the hash table (number of slots) --> power of 2!
 #if LLMSSET_MASK
-    size_t            mask;         // size-1
+    size_t             mask;         // size-1
 #endif
-    size_t            f_size;
-    llmsset_hash_cb   hash_cb;      // custom hash function
-    llmsset_equals_cb equals_cb;    // custom equals function
-    llmsset_create_cb create_cb;    // custom create function
-    llmsset_destroy_cb destroy_cb;  // custom destroy function
-    int16_t           threshold;    // number of iterations for insertion until returning error
+    size_t             f_size;
+    llmsset_hash_cb    hash_cb;      // custom hash function
+    llmsset_equals_cb  equals_cb;    // custom equals function
+    llmsset_create_cb  create_cb;    // custom create function
+    llmsset_destroy_cb destroy_cb;   // custom destroy function
+    _Atomic(int16_t)   threshold;    // number of iterations for insertion until returning error
 } *llmsset_t;
 
 /**

--- a/test/test_mtbdd.c
+++ b/test/test_mtbdd.c
@@ -85,10 +85,10 @@ test_mtbdd_makenodes_and_leafs_boolean_terminals()
     MTBDD index_leaf_10 = mtbdd_makeleaf(terminal_type, value_low_10);
     MTBDD index_leaf_11 = mtbdd_makeleaf(terminal_type, value_high_11);
 
-    printf("index_leaf_00 = %ld \n", index_leaf_00);
-    printf("index_leaf_01 = %ld \n", index_leaf_01);
-    printf("index_leaf_10 = %ld \n", index_leaf_10);
-    printf("index_leaf_11 = %ld \n", index_leaf_11);
+    printf("index_leaf_00 = %llu \n", index_leaf_00);
+    printf("index_leaf_01 = %llu \n", index_leaf_01);
+    printf("index_leaf_10 = %llu \n", index_leaf_10);
+    printf("index_leaf_11 = %llu \n", index_leaf_11);
 
     // Identical terminals must have the same index
     test_assert(index_leaf_00 == index_leaf_10);
@@ -99,8 +99,8 @@ test_mtbdd_makenodes_and_leafs_boolean_terminals()
     MTBDD index_x1_low  = mtbdd_makenode(index_x2, index_leaf_00, index_leaf_01);
     MTBDD index_x1_high = mtbdd_makenode(index_x2, index_leaf_10, index_leaf_11);
 
-    printf("index_x1_low  = %ld \n", index_x1_low);
-    printf("index_x1_high = %ld \n", index_x1_high);
+    printf("index_x1_low  = %llu \n", index_x1_low);
+    printf("index_x1_high = %llu \n", index_x1_high);
 
     // The indices of x1 should be identical
     test_assert(index_x1_low == index_x1_high);
@@ -109,7 +109,7 @@ test_mtbdd_makenodes_and_leafs_boolean_terminals()
     uint32_t index_x1 = 1;
     MTBDD index_root_node = mtbdd_makenode(index_x1, index_x1_low, index_x1_high);
 
-    printf("index_root_node = %ld \n", index_root_node);
+    printf("index_root_node = %llu \n", index_root_node);
 
     // The index of root should be the indices of x1
     test_assert(index_root_node == index_x1_low);
@@ -156,10 +156,10 @@ test_mtbdd_makenodes_and_leafs_integer_terminals()
     MTBDD index_leaf_10 = mtbdd_makeleaf(terminal_type, value_low_10);
     MTBDD index_leaf_11 = mtbdd_makeleaf(terminal_type, value_high_11);
 
-    printf("index_leaf_00 = %ld \n", index_leaf_00);
-    printf("index_leaf_01 = %ld \n", index_leaf_01);
-    printf("index_leaf_10 = %ld \n", index_leaf_10);
-    printf("index_leaf_11 = %ld \n", index_leaf_11);
+    printf("index_leaf_00 = %llu \n", index_leaf_00);
+    printf("index_leaf_01 = %llu \n", index_leaf_01);
+    printf("index_leaf_10 = %llu \n", index_leaf_10);
+    printf("index_leaf_11 = %llu \n", index_leaf_11);
 
     // Different terminals should have different indices
     test_assert(index_leaf_00 != index_leaf_10); 
@@ -170,8 +170,8 @@ test_mtbdd_makenodes_and_leafs_integer_terminals()
     MTBDD index_x1_low  = mtbdd_makenode(index_x2, index_leaf_00, index_leaf_01);
     MTBDD index_x1_high = mtbdd_makenode(index_x2, index_leaf_10, index_leaf_11);
 
-    printf("index_x1_low  = %ld \n", index_x1_low);
-    printf("index_x1_high = %ld \n", index_x1_high);
+    printf("index_x1_low  = %llu \n", index_x1_low);
+    printf("index_x1_high = %llu \n", index_x1_high);
 
     // The indices of x1 should be different
     test_assert(index_x1_low != index_x1_high);
@@ -180,7 +180,7 @@ test_mtbdd_makenodes_and_leafs_integer_terminals()
     uint32_t index_x1 = 1;
     MTBDD index_root_node = mtbdd_makenode(index_x1, index_x1_low, index_x1_high);
 
-    printf("index_root_node = %ld \n", index_root_node);
+    printf("index_root_node = %llu \n", index_root_node);
 
     // The index of root should be the indices of x1
     test_assert(index_root_node != index_x1_low);
@@ -244,10 +244,10 @@ test_mtbdd_makenodes_and_leafs_real_terminals()
     MTBDD index_leaf_10 = mtbdd_double(/*terminal_type,*/ value_low_10);
     MTBDD index_leaf_11 = mtbdd_double(/*terminal_type,*/ value_high_11);
 
-    printf("index_leaf_00 = %ld \n", index_leaf_00);
-    printf("index_leaf_01 = %ld \n", index_leaf_01);
-    printf("index_leaf_10 = %ld \n", index_leaf_10);
-    printf("index_leaf_11 = %ld \n", index_leaf_11);
+    printf("index_leaf_00 = %llu \n", index_leaf_00);
+    printf("index_leaf_01 = %llu \n", index_leaf_01);
+    printf("index_leaf_10 = %llu \n", index_leaf_10);
+    printf("index_leaf_11 = %llu \n", index_leaf_11);
 
     // Different terminals should have different indices
     test_assert(index_leaf_00 == index_leaf_01); 
@@ -258,8 +258,8 @@ test_mtbdd_makenodes_and_leafs_real_terminals()
     MTBDD index_x1_low  = mtbdd_makenode(index_x2, index_leaf_00, index_leaf_01);
     MTBDD index_x1_high = mtbdd_makenode(index_x2, index_leaf_10, index_leaf_11);
 
-    printf("index_x1_low  = %ld \n", index_x1_low);
-    printf("index_x1_high = %ld \n", index_x1_high);
+    printf("index_x1_low  = %llu \n", index_x1_low);
+    printf("index_x1_high = %llu \n", index_x1_high);
 
     // The indices of x1 should be different
     test_assert(index_x1_low != index_x1_high);
@@ -270,7 +270,7 @@ test_mtbdd_makenodes_and_leafs_real_terminals()
     uint32_t index_x1 = 1;
     MTBDD index_root_node = mtbdd_makenode(index_x1, index_x1_low, index_x1_high);
 
-    printf("index_root_node = %ld \n", index_root_node);
+    printf("index_root_node = %llu \n", index_root_node);
 
     // The index of root should be the indices of x1
     test_assert(index_root_node != index_x1_low);
@@ -305,7 +305,7 @@ test_mtbdd_makenodes_and_leafs_real_terminals()
     // - test getlow/high of a node
 
     printf("test: getlow/high of a node \n");
-    printf("getlow(index_root_node = %ld) = %ld == index_x1_low = %ld \n", index_root_node, mtbdd_getlow(index_root_node), index_x1_low);
+    printf("getlow(index_root_node = %llu) = %llu == index_x1_low = %llu \n", index_root_node, mtbdd_getlow(index_root_node), index_x1_low);
     
     test_assert(mtbdd_getlow(index_root_node) == index_x1_low);
     test_assert(mtbdd_gethigh(index_root_node) == index_x1_high);
@@ -321,7 +321,7 @@ test_mtbdd_makenodes_and_leafs_real_terminals()
     // - test get type/value of non terminals
 
     printf("gettype(index_x1_low)  = %d \n", mtbdd_gettype(index_x1_low));
-    printf("getvalue(index_x1_low) = %ld \n", mtbdd_getvalue(index_x1_low));
+    printf("getvalue(index_x1_low) = %llu \n", mtbdd_getvalue(index_x1_low));
 
     test_assert(mtbdd_gettype(index_x1_low) == 1);  // not a leaf, 
     test_assert(mtbdd_getvalue(index_x1_low) == 0); // not a leaf, TODO: what to return if no value?
@@ -378,30 +378,30 @@ test_mtbdd_arithmic_functions()
     MTBDD index_leaf_10 = mtbdd_double(0.35);
     MTBDD index_leaf_11 = mtbdd_double(0.65);
 
-    printf("index_leaf_00 = %ld \n", index_leaf_00);
-    printf("index_leaf_01 = %ld \n", index_leaf_01);
-    printf("index_leaf_10 = %ld \n", index_leaf_10);
-    printf("index_leaf_11 = %ld \n", index_leaf_11);
+    printf("index_leaf_00 = %llu \n", index_leaf_00);
+    printf("index_leaf_01 = %llu \n", index_leaf_01);
+    printf("index_leaf_10 = %llu \n", index_leaf_10);
+    printf("index_leaf_11 = %llu \n", index_leaf_11);
 
     // Make non-terminal nodes - middle layer, so variable x2
     uint32_t index_x2 = 2;
     MTBDD index_x1_low  = mtbdd_makenode(index_x2, index_leaf_00, index_leaf_01);
     MTBDD index_x1_high = mtbdd_makenode(index_x2, index_leaf_10, index_leaf_11);
 
-    printf("index_x1_low  = %ld \n", index_x1_low);
-    printf("index_x1_high = %ld \n", index_x1_high);
+    printf("index_x1_low  = %llu \n", index_x1_low);
+    printf("index_x1_high = %llu \n", index_x1_high);
 
     // Make root node (= non terminal node) - top layer, so variable x1
     uint32_t index_x1 = 1;
     MTBDD index_root_node = mtbdd_makenode(index_x1, index_x1_low, index_x1_high);
 
-    printf("index_root_node = %ld \n", index_root_node);
+    printf("index_root_node = %llu \n", index_root_node);
 
     dd1 = index_root_node;
 
     // Compute a + b
     dd_plus = mtbdd_plus(dd1, dd1);
-    printf("dd_plus = %ld \n", dd_plus);
+    printf("dd_plus = %llu \n", dd_plus);
     printf("terminal 00 = %lf \n", mtbdd_getdouble(mtbdd_getlow(mtbdd_getlow(dd_plus))));
     printf("terminal 01 = %lf \n", mtbdd_getdouble(mtbdd_gethigh(mtbdd_getlow(dd_plus))));
     printf("terminal 10 = %lf \n", mtbdd_getdouble(mtbdd_getlow(mtbdd_gethigh(dd_plus))));
@@ -414,7 +414,7 @@ test_mtbdd_arithmic_functions()
 
     // Compute a - b
     dd_minus = mtbdd_minus(dd1, dd1);
-    printf("dd_minus = %ld \n", dd_minus);
+    printf("dd_minus = %llu \n", dd_minus);
     printf("terminal 00 = %lf \n", mtbdd_getdouble(mtbdd_getlow(mtbdd_getlow(dd_minus))));
     printf("terminal 01 = %lf \n", mtbdd_getdouble(mtbdd_gethigh(mtbdd_getlow(dd_minus))));
     printf("terminal 10 = %lf \n", mtbdd_getdouble(mtbdd_getlow(mtbdd_gethigh(dd_minus))));
@@ -427,7 +427,7 @@ test_mtbdd_arithmic_functions()
 
     // Compute a * b
     dd_times = mtbdd_times(dd1, dd1);
-    printf("dd_times = %ld \n", dd_times);
+    printf("dd_times = %llu \n", dd_times);
     printf("terminal 00 = %lf \n", mtbdd_getdouble(mtbdd_getlow(mtbdd_getlow(dd_times))));
     printf("terminal 01 = %lf \n", mtbdd_getdouble(mtbdd_gethigh(mtbdd_getlow(dd_times))));
     printf("terminal 10 = %lf \n", mtbdd_getdouble(mtbdd_getlow(mtbdd_gethigh(dd_times))));
@@ -453,8 +453,8 @@ test_mtbdd_arithmic_functions()
     index_x1_low  = mtbdd_makenode(index_x2, index_leaf_00, index_leaf_01);
     index_x1_high = mtbdd_makenode(index_x2, index_leaf_10, index_leaf_11);
 
-    printf("index_x1_low  = %ld \n", index_x1_low);
-    printf("index_x1_high = %ld \n", index_x1_high);
+    printf("index_x1_low  = %llu \n", index_x1_low);
+    printf("index_x1_high = %llu \n", index_x1_high);
 
     // Make root node (= non terminal node) - top layer, so variable x1
     index_x1 = 1;
@@ -463,7 +463,7 @@ test_mtbdd_arithmic_functions()
 
     // Compute min(a, b)
     dd_min = mtbdd_min(dd1, dd2);
-    printf("dd_min = %ld \n", dd_min);
+    printf("dd_min = %llu \n", dd_min);
     printf("isleaf = %d \n", mtbddnode_isleaf(MTBDD_GETNODE(dd_min)));
     printf("type = %d \n", mtbddnode_gettype(MTBDD_GETNODE(mtbdd_getlow(mtbdd_getlow(dd_min)))));
     printf("terminal 00 = %lf \n", mtbdd_getdouble(mtbdd_getlow(mtbdd_getlow(dd_min))));
@@ -477,7 +477,7 @@ test_mtbdd_arithmic_functions()
 
     // Compute max(a, b)
     dd_max = mtbdd_max(dd1, dd2);
-    printf("dd_max = %ld \n", dd_max);
+    printf("dd_max = %llu \n", dd_max);
     printf("terminal 00 = %lf \n", mtbdd_getdouble(mtbdd_getlow(mtbdd_getlow(dd_max))));
     printf("terminal 0x = %lf \n", mtbdd_getdouble(mtbdd_getlow(dd_max)));
     printf("terminal 1x = %lf \n", mtbdd_getdouble(mtbdd_gethigh(dd_max)));
@@ -537,24 +537,24 @@ test_mtbdd_abstract_plus_function_1()
     MTBDD index_leaf_10 = mtbdd_double(0.35);
     MTBDD index_leaf_11 = mtbdd_double(0.75);
 
-    printf("index_leaf_00 = %ld \n", index_leaf_00);
-    printf("index_leaf_01 = %ld \n", index_leaf_01);
-    printf("index_leaf_10 = %ld \n", index_leaf_10);
-    printf("index_leaf_11 = %ld \n", index_leaf_11);
+    printf("index_leaf_00 = %llu \n", index_leaf_00);
+    printf("index_leaf_01 = %llu \n", index_leaf_01);
+    printf("index_leaf_10 = %llu \n", index_leaf_10);
+    printf("index_leaf_11 = %llu \n", index_leaf_11);
 
     // Make non-terminal nodes - middle layer, so variable x2
     uint32_t index_x2 = 2;
     MTBDD index_x0_low  = mtbdd_makenode(index_x2, index_leaf_00, index_leaf_01);
     MTBDD index_x0_high = mtbdd_makenode(index_x2, index_leaf_10, index_leaf_11);
 
-    printf("index_x0_low  = %ld \n", index_x0_low);
-    printf("index_x0_high = %ld \n", index_x0_high);
+    printf("index_x0_low  = %llu \n", index_x0_low);
+    printf("index_x0_high = %llu \n", index_x0_high);
 
     // Make root node (= non terminal node) - top layer, so variable x1
     uint32_t index_x1 = 1;
     MTBDD index_x0 = mtbdd_makenode(index_x1, index_x0_low, index_x0_high);
 
-    printf("index_x0 = %ld \n", index_x0);
+    printf("index_x0 = %llu \n", index_x0);
 
     dd = index_x0;
 
@@ -584,12 +584,12 @@ test_mtbdd_abstract_plus_function_1()
     fclose(out);
 
     // Print all kinds of gets
-    printf("dd_plus       = %ld\n", dd_plus);
+    printf("dd_plus       = %llu\n", dd_plus);
     printf("getnumer      = %d \n", mtbdd_getnumer(dd_plus));
     printf("getdouble     = %lf\n", mtbdd_getdouble(dd_plus));
-    printf("getvalue      = %ld\n", mtbdd_getvalue(dd_plus));
-    printf("getlow        = %ld\n", mtbdd_getlow(dd_plus));
-    printf("gethigh       = %ld\n", mtbdd_gethigh(dd_plus));
+    printf("getvalue      = %llu\n", mtbdd_getvalue(dd_plus));
+    printf("getlow        = %llu\n", mtbdd_getlow(dd_plus));
+    printf("gethigh       = %llu\n", mtbdd_gethigh(dd_plus));
     printf("getvar        = %d \n", mtbdd_getvar(dd_plus));  // index_x2 (index_x0)
 
     printf("getlow(low)   00 = %lf\n", mtbdd_getdouble( mtbdd_getlow(dd_plus)));
@@ -648,24 +648,24 @@ test_mtbdd_abstract_plus_function_2()
     MTBDD index_leaf_10 = mtbdd_double(0.35);
     MTBDD index_leaf_11 = mtbdd_double(0.75);
 
-    printf("index_leaf_00 = %ld \n", index_leaf_00);
-    printf("index_leaf_01 = %ld \n", index_leaf_01);
-    printf("index_leaf_10 = %ld \n", index_leaf_10);
-    printf("index_leaf_11 = %ld \n", index_leaf_11);
+    printf("index_leaf_00 = %llu \n", index_leaf_00);
+    printf("index_leaf_01 = %llu \n", index_leaf_01);
+    printf("index_leaf_10 = %llu \n", index_leaf_10);
+    printf("index_leaf_11 = %llu \n", index_leaf_11);
 
     // Make non-terminal nodes - middle layer, so variable x2
     uint32_t index_x2 = 2;
     MTBDD index_x0_low  = mtbdd_makenode(index_x2, index_leaf_00, index_leaf_01);
     MTBDD index_x0_high = mtbdd_makenode(index_x2, index_leaf_10, index_leaf_11);
 
-    printf("index_x0_low  = %ld \n", index_x0_low);
-    printf("index_x0_high = %ld \n", index_x0_high);
+    printf("index_x0_low  = %llu \n", index_x0_low);
+    printf("index_x0_high = %llu \n", index_x0_high);
 
     // Make root node (= non terminal node) - top layer, so variable x1
     uint32_t index_x1 = 1;
     MTBDD index_x0 = mtbdd_makenode(index_x1, index_x0_low, index_x0_high);
 
-    printf("index_x0 = %ld \n", index_x0);
+    printf("index_x0 = %llu \n", index_x0);
 
     dd = index_x0;
 
@@ -695,12 +695,12 @@ test_mtbdd_abstract_plus_function_2()
     fclose(out);
 
     // Print all kinds of gets
-    printf("dd_plus       = %ld\n", dd_plus);
+    printf("dd_plus       = %llu\n", dd_plus);
     printf("getnumer      = %d \n", mtbdd_getnumer(dd_plus));
     printf("getdouble     = %lf\n", mtbdd_getdouble(dd_plus));
-    printf("getvalue      = %ld\n", mtbdd_getvalue(dd_plus));
-    printf("getlow        = %ld\n", mtbdd_getlow(dd_plus));
-    printf("gethigh       = %ld\n", mtbdd_gethigh(dd_plus));
+    printf("getvalue      = %llu\n", mtbdd_getvalue(dd_plus));
+    printf("getlow        = %llu\n", mtbdd_getlow(dd_plus));
+    printf("gethigh       = %llu\n", mtbdd_gethigh(dd_plus));
     printf("getvar        = %d \n", mtbdd_getvar(dd_plus));  // index_x1 (index_x0)
 
     printf("getlow(low)   00 = %lf\n", mtbdd_getdouble( mtbdd_getlow(dd_plus)));
@@ -757,24 +757,24 @@ test_mtbdd_abstract_plus_min_max_times_function_3()
     MTBDD index_leaf_10 = mtbdd_double(0.35);
     MTBDD index_leaf_11 = mtbdd_double(0.75);
 
-    printf("index_leaf_00 = %ld \n", index_leaf_00);
-    printf("index_leaf_01 = %ld \n", index_leaf_01);
-    printf("index_leaf_10 = %ld \n", index_leaf_10);
-    printf("index_leaf_11 = %ld \n", index_leaf_11);
+    printf("index_leaf_00 = %llu \n", index_leaf_00);
+    printf("index_leaf_01 = %llu \n", index_leaf_01);
+    printf("index_leaf_10 = %llu \n", index_leaf_10);
+    printf("index_leaf_11 = %llu \n", index_leaf_11);
 
     // Make non-terminal nodes - middle layer, so variable x2
     uint32_t index_x2 = 2;
     MTBDD index_x0_low  = mtbdd_makenode(index_x2, index_leaf_00, index_leaf_01);
     MTBDD index_x0_high = mtbdd_makenode(index_x2, index_leaf_10, index_leaf_11);
 
-    printf("index_x0_low  = %ld \n", index_x0_low);
-    printf("index_x0_high = %ld \n", index_x0_high);
+    printf("index_x0_low  = %llu \n", index_x0_low);
+    printf("index_x0_high = %llu \n", index_x0_high);
 
     // Make root node (= non terminal node) - top layer, so variable x1
     uint32_t index_x1 = 1;
     MTBDD index_x0 = mtbdd_makenode(index_x1, index_x0_low, index_x0_high);
 
-    printf("index_x0 = %ld \n", index_x0);
+    printf("index_x0 = %llu \n", index_x0);
 
     dd = index_x0;
 
@@ -804,12 +804,12 @@ test_mtbdd_abstract_plus_min_max_times_function_3()
     fclose(out);
 
     // Print all kinds of gets
-    printf("dd_plus       = %ld\n", dd_plus);
+    printf("dd_plus       = %llu\n", dd_plus);
     printf("getnumer      = %d \n", mtbdd_getnumer(dd_plus));
     printf("getdouble     = %lf\n", mtbdd_getdouble(dd_plus));
-    printf("getvalue      = %ld\n", mtbdd_getvalue(dd_plus));
-    printf("getlow        = %ld\n", mtbdd_getlow(dd_plus));
-    printf("gethigh       = %ld\n", mtbdd_gethigh(dd_plus));
+    printf("getvalue      = %llu\n", mtbdd_getvalue(dd_plus));
+    printf("getlow        = %llu\n", mtbdd_getlow(dd_plus));
+    printf("gethigh       = %llu\n", mtbdd_gethigh(dd_plus));
     printf("getvar        = %d \n", mtbdd_getvar(dd_plus));  // index_x0 undefined
 
     assert(mtbdd_getdouble(dd_plus)  == 2.1);
@@ -922,24 +922,24 @@ test_mtbdd_and_abstract_plus_function()
     MTBDD index_leaf_10 = mtbdd_double(0.75);
     MTBDD index_leaf_11 = mtbdd_double(0.65);
 
-    printf("index_leaf_00 = %ld \n", index_leaf_00);
-    printf("index_leaf_01 = %ld \n", index_leaf_01);
-    printf("index_leaf_10 = %ld \n", index_leaf_10);
-    printf("index_leaf_11 = %ld \n", index_leaf_11);
+    printf("index_leaf_00 = %llu \n", index_leaf_00);
+    printf("index_leaf_01 = %llu \n", index_leaf_01);
+    printf("index_leaf_10 = %llu \n", index_leaf_10);
+    printf("index_leaf_11 = %llu \n", index_leaf_11);
 
     // Make non-terminal nodes - middle layer, so variable x2
     uint32_t index_x2 = 2;
     MTBDD index_x0_low  = mtbdd_makenode(index_x2, index_leaf_00, index_leaf_01);
     MTBDD index_x0_high = mtbdd_makenode(index_x2, index_leaf_10, index_leaf_11);
 
-    printf("index_x0_low  = %ld \n", index_x0_low);
-    printf("index_x0_high = %ld \n", index_x0_high);
+    printf("index_x0_low  = %llu \n", index_x0_low);
+    printf("index_x0_high = %llu \n", index_x0_high);
 
     // Make root node (= non terminal node) - top layer, so variable x1
     uint32_t index_x1 = 1;
     MTBDD index_x0 = mtbdd_makenode(index_x1, index_x0_low, index_x0_high);
 
-    printf("index_x0 = %ld \n", index_x0);
+    printf("index_x0 = %llu \n", index_x0);
 
     M = index_x0;
 
@@ -953,24 +953,24 @@ test_mtbdd_and_abstract_plus_function()
     index_leaf_10 = mtbdd_double(0.35);
     index_leaf_11 = mtbdd_double(0.65);
 
-    printf("index_leaf_00 = %ld \n", index_leaf_00);
-    printf("index_leaf_01 = %ld \n", index_leaf_01);
-    printf("index_leaf_10 = %ld \n", index_leaf_10);
-    printf("index_leaf_11 = %ld \n", index_leaf_11);
+    printf("index_leaf_00 = %llu \n", index_leaf_00);
+    printf("index_leaf_01 = %llu \n", index_leaf_01);
+    printf("index_leaf_10 = %llu \n", index_leaf_10);
+    printf("index_leaf_11 = %llu \n", index_leaf_11);
 
     // Make non-terminal nodes - middle layer, so variable x2
     index_x2 = 2;
     index_x0_low  = mtbdd_makenode(index_x2, index_leaf_00, index_leaf_01);
     index_x0_high = mtbdd_makenode(index_x2, index_leaf_10, index_leaf_11);
 
-    printf("index_x0_low  = %ld \n", index_x0_low);
-    printf("index_x0_high = %ld \n", index_x0_high);
+    printf("index_x0_low  = %llu \n", index_x0_low);
+    printf("index_x0_high = %llu \n", index_x0_high);
 
     // Make root node (= non terminal node) - top layer, so variable x1
     index_x1 = 1;
     index_x0 = mtbdd_makenode(index_x1, index_x0_low, index_x0_high);
 
-    printf("index_x0 = %ld \n", index_x0);
+    printf("index_x0 = %llu \n", index_x0);
 
     M_ = index_x0;
 
@@ -982,14 +982,14 @@ test_mtbdd_and_abstract_plus_function()
     MTBDD index_leaf_0 = mtbdd_double(3.0);
     MTBDD index_leaf_1 = mtbdd_double(2.0);
 
-    printf("index_leaf_0 = %ld \n", index_leaf_0);
-    printf("index_leaf_1 = %ld \n", index_leaf_1);
+    printf("index_leaf_0 = %llu \n", index_leaf_0);
+    printf("index_leaf_1 = %llu \n", index_leaf_1);
 
     // Make root node (= non terminal node) - top layer, so variable x1
     index_x1 = 1;
     index_x0 = mtbdd_makenode(index_x1, index_leaf_0, index_leaf_1);
 
-    printf("index_x0 = %ld \n", index_x0);
+    printf("index_x0 = %llu \n", index_x0);
 
     v = index_x0;
 
@@ -1013,12 +1013,12 @@ test_mtbdd_and_abstract_plus_function()
     fclose(out);
 
     // Print all kinds of gets
-    printf("w             = %ld\n", w);
+    printf("w             = %llu\n", w);
     printf("getnumer      = %d \n", mtbdd_getnumer(w));
     printf("getdouble     = %lf\n", mtbdd_getdouble(w));
-    printf("getvalue      = %ld\n", mtbdd_getvalue(w));
-    printf("getlow        = %ld\n", mtbdd_getlow(w));
-    printf("gethigh       = %ld\n", mtbdd_gethigh(w));
+    printf("getvalue      = %llu\n", mtbdd_getvalue(w));
+    printf("getlow        = %llu\n", mtbdd_getlow(w));
+    printf("gethigh       = %llu\n", mtbdd_gethigh(w));
     printf("getvar        = %d \n", mtbdd_getvar(w));
 
     printf("getdouble(getlow)   0 = %lf\n", mtbdd_getdouble( mtbdd_getlow(w)  ));
@@ -1047,12 +1047,12 @@ test_mtbdd_and_abstract_plus_function()
     fclose(out);
 
     // Print all kinds of gets
-    printf("w             = %ld\n", w_);
+    printf("w             = %llu\n", w_);
     printf("getnumer      = %d \n", mtbdd_getnumer(w_));
     printf("getdouble     = %lf\n", mtbdd_getdouble(w_));
-    printf("getvalue      = %ld\n", mtbdd_getvalue(w_));
-    printf("getlow        = %ld\n", mtbdd_getlow(w_));
-    printf("gethigh       = %ld\n", mtbdd_gethigh(w_));
+    printf("getvalue      = %llu\n", mtbdd_getvalue(w_));
+    printf("getlow        = %llu\n", mtbdd_getlow(w_));
+    printf("gethigh       = %llu\n", mtbdd_gethigh(w_));
     printf("getvar        = %d \n", mtbdd_getvar(w_));
 
     printf("getdouble(getlow)   0 = %lf\n", mtbdd_getdouble( mtbdd_getlow(w_)  ));

--- a/test/test_qmdd_basics.c
+++ b/test/test_qmdd_basics.c
@@ -5,6 +5,7 @@
 #include <sylvan.h>
 #include <sylvan_aadd.h>
 #include <sylvan_edge_weights.h>
+#include <sylvan_edge_weights_complex.h>
 
 #include "test_assert.h"
 
@@ -35,72 +36,72 @@ int test_complex_operations() // No influence on DD
     test_assert(weight_eq(&ref1, &ref2));
 
     // test AADD_ZERO
-    ref1 = cmake(0.0, 0.0);         index1 = weight_lookup(ref1);
-    ref2 = cmake(0.0, 0.0);         index2 = weight_lookup(ref2);
-    ref3 = czero();                 index3 = weight_lookup(ref3);
+    ref1 = cmake(0.0, 0.0);         index1 = weight_lookup(&ref1);
+    ref2 = cmake(0.0, 0.0);         index2 = weight_lookup(&ref2);
+    ref3 = czero();                 index3 = weight_lookup(&ref3);
     test_assert(index1 == index2);
     test_assert(index1 == index3);
     test_assert(index1 == AADD_ZERO);
 
     // test AADD_ONE
-    ref1 = cmake(1.0, 0.0);         index1 = weight_lookup(ref1);
-    ref2 = cmake(1.0, 0.0);         index2 = weight_lookup(ref2);
+    ref1 = cmake(1.0, 0.0);         index1 = weight_lookup(&ref1);
+    ref2 = cmake(1.0, 0.0);         index2 = weight_lookup(&ref2);
     test_assert(index1 == index2);
     test_assert(index1 == AADD_ONE);
 
     // Clookup, Cvalue
-    ref1 = cmake(0.5, 0.0);              index1 = weight_lookup(ref1);   weight_value(index1, &val1);
-    ref2 = cmake(0.5, 0.0);              index2 = weight_lookup(ref2);   weight_value(index2, &val2);
-    ref3 = cmake(1.0/flt_sqrt(2.0),0);   index3 = weight_lookup(ref3);   weight_value(index3, &val3);
-    ref4 = cmake(1.0/flt_sqrt(2.0),0);   index4 = weight_lookup(ref4);   weight_value(index4, &val4);
+    ref1 = cmake(0.5, 0.0);              index1 = weight_lookup(&ref1);   weight_value(index1, &val1);
+    ref2 = cmake(0.5, 0.0);              index2 = weight_lookup(&ref2);   weight_value(index2, &val2);
+    ref3 = cmake(1.0/flt_sqrt(2.0),0);   index3 = weight_lookup(&ref3);   weight_value(index3, &val3);
+    ref4 = cmake(1.0/flt_sqrt(2.0),0);   index4 = weight_lookup(&ref4);   weight_value(index4, &val4);
     test_assert(index1 == index2);  test_assert(weight_eq(&val1, &val2));
     test_assert(index3 == index4);  test_assert(weight_eq(&val3, &val4));
 
     // wgt_neg
-    ref1 = cmake(0.3, 4.2);         index1 = weight_lookup(ref1);   weight_value(index1, &val1);
-    ref2 = cmake(-0.3, -4.2);       index2 = weight_lookup(ref2);   weight_value(index2, &val2);
+    ref1 = cmake(0.3, 4.2);         index1 = weight_lookup(&ref1);   weight_value(index1, &val1);
+    ref2 = cmake(-0.3, -4.2);       index2 = weight_lookup(&ref2);   weight_value(index2, &val2);
     index3 = wgt_neg(index1);       weight_value(index3, &val3);
     index4 = wgt_neg(index2);       weight_value(index4, &val4);
     test_assert(index1 == index4);  test_assert(weight_eq(&val1, &val4));
     test_assert(index2 == index3);  test_assert(weight_eq(&val2, &val3));
 
     // wgt_add
-    ref1 = cmake(5.2, 1.0);         index1 = weight_lookup(ref1);   weight_value(index1, &val1);
-    ref2 = cmake(-0.3,7.0);         index2 = weight_lookup(ref2);   weight_value(index2, &val2);
-    ref3 = cmake(4.9, 8.0);         index3 = weight_lookup(ref3);   weight_value(index3, &val3);
+    ref1 = cmake(5.2, 1.0);         index1 = weight_lookup(&ref1);   weight_value(index1, &val1);
+    ref2 = cmake(-0.3,7.0);         index2 = weight_lookup(&ref2);   weight_value(index2, &val2);
+    ref3 = cmake(4.9, 8.0);         index3 = weight_lookup(&ref3);   weight_value(index3, &val3);
     index4=wgt_add(index1,index2);  weight_value(index4, &val4);
     test_assert(index3 == index4);  test_assert(weight_eq(&val3, &val4));
 
     // wgt_sub
-    ref1 = cmake(1/3, 3.5);         index1 = weight_lookup(ref1);   weight_value(index1, &val1);
-    ref2 = cmake(1/3,-1.2);         index2 = weight_lookup(ref2);   weight_value(index2, &val2);
-    ref3 = cmake(0.0, 4.7);         index3 = weight_lookup(ref3);   weight_value(index3, &val3);
+    ref1 = cmake(1/3, 3.5);         index1 = weight_lookup(&ref1);   weight_value(index1, &val1);
+    ref2 = cmake(1/3,-1.2);         index2 = weight_lookup(&ref2);   weight_value(index2, &val2);
+    ref3 = cmake(0.0, 4.7);         index3 = weight_lookup(&ref3);   weight_value(index3, &val3);
     index4=wgt_sub(index1,index2);  weight_value(index4, &val4);
     test_assert(index3 == index4);  test_assert(weight_eq(&val3, &val4));
     
     // wgt_mul
-    ref1 = cmake(3.0, 5.0);         index1 = weight_lookup(ref1);   weight_value(index1, &val1);
-    ref2 = cmake(0.5, 7.0);         index2 = weight_lookup(ref2);   weight_value(index2, &val2);
-    ref3 = cmake(-33.5, 23.5);      index3 = weight_lookup(ref3);   weight_value(index3, &val3);
+    ref1 = cmake(3.0, 5.0);         index1 = weight_lookup(&ref1);   weight_value(index1, &val1);
+    ref2 = cmake(0.5, 7.0);         index2 = weight_lookup(&ref2);   weight_value(index2, &val2);
+    ref3 = cmake(-33.5, 23.5);      index3 = weight_lookup(&ref3);   weight_value(index3, &val3);
     index4=wgt_mul(index1,index2);  weight_value(index4, &val4);
     test_assert(index3 == index4);  test_assert(weight_eq(&val3, &val4));
 
-    ref1 = cmake(1.0/flt_sqrt(2.0),0);   index1 = weight_lookup(ref1);   weight_value(index1, &val1);
-    ref2 = cmake(1.0/flt_sqrt(2.0),0);   index2 = weight_lookup(ref2);   weight_value(index2, &val2);
-    ref3 = cmake(0.5, 0.0);              index3 = weight_lookup(ref3);   weight_value(index3, &val3);
+    ref1 = cmake(1.0/flt_sqrt(2.0),0);   index1 = weight_lookup(&ref1);   weight_value(index1, &val1);
+    ref2 = cmake(1.0/flt_sqrt(2.0),0);   index2 = weight_lookup(&ref2);   weight_value(index2, &val2);
+    ref3 = cmake(0.5, 0.0);              index3 = weight_lookup(&ref3);   weight_value(index3, &val3);
     index4=wgt_mul(index1,index2);  weight_value(index4, &val4);
     test_assert(index3 == index4);  test_assert(weight_eq(&val3, &val4));
 
     // wgt_div
-    ref1 = cmake(1.3,-0.7);         index1 = weight_lookup(ref1);   weight_value(index1, &val1);
-    ref2 = cmake(1.0, 0.0);         index2 = weight_lookup(ref2);   weight_value(index2, &val2);
-    ref3 = cmake(1.3,-0.7);         index3 = weight_lookup(ref3);   weight_value(index3, &val3);
+    ref1 = cmake(1.3,-0.7);         index1 = weight_lookup(&ref1);   weight_value(index1, &val1);
+    ref2 = cmake(1.0, 0.0);         index2 = weight_lookup(&ref2);   weight_value(index2, &val2);
+    ref3 = cmake(1.3,-0.7);         index3 = weight_lookup(&ref3);   weight_value(index3, &val3);
     index4=wgt_div(index1,index2);  weight_value(index4, &val4);
     test_assert(index3 == index4);  test_assert(weight_eq(&val3, &val4));
 
-    ref1 = cmake(5.0, 9.0);         index1 = weight_lookup(ref1);   weight_value(index1, &val1);
-    ref2 = cmake(-4.0,7.0);         index2 = weight_lookup(ref2);   weight_value(index2, &val2);
-    ref3 = cmake(43./65.,-71./65.); index3 = weight_lookup(ref3);   weight_value(index3, &val3);
+    ref1 = cmake(5.0, 9.0);         index1 = weight_lookup(&ref1);   weight_value(index1, &val1);
+    ref2 = cmake(-4.0,7.0);         index2 = weight_lookup(&ref2);   weight_value(index2, &val2);
+    ref3 = cmake(43./65.,-71./65.); index3 = weight_lookup(&ref3);   weight_value(index3, &val3);
     index4=wgt_div(index1, index2); weight_value(index4, &val4);
     test_assert(index3 == index4);  test_assert(weight_eq(&val3, &val4));
 
@@ -182,24 +183,24 @@ int test_vector_addition()
     q010 = aadd_plus(q01, q0);
     q100 = aadd_plus(q10, q0);
 
-    x[0] = 0; a = aadd_getvalue(q00, x); test_assert(a == weight_lookup(cmake(2.0, 0.0)));
+    x[0] = 0; a = aadd_getvalue(q00, x); test_assert(a == complex_lookup(2.0, 0.0));
     x[0] = 1; a = aadd_getvalue(q00, x); test_assert(a == AADD_ZERO);
     x[0] = 0; a = aadd_getvalue(q01, x); test_assert(a == AADD_ONE);
     x[0] = 1; a = aadd_getvalue(q01, x); test_assert(a == AADD_ONE);
     x[0] = 0; a = aadd_getvalue(q10, x); test_assert(a == AADD_ONE);
     x[0] = 1; a = aadd_getvalue(q10, x); test_assert(a == AADD_ONE);
     x[0] = 0; a = aadd_getvalue(q11, x); test_assert(a == AADD_ZERO);
-    x[0] = 1; a = aadd_getvalue(q11, x); test_assert(a == weight_lookup(cmake(2.0, 0.0)));
+    x[0] = 1; a = aadd_getvalue(q11, x); test_assert(a == complex_lookup(2.0, 0.0));
     test_assert(q01 == q10);
     test_assert(!qmdd_is_unitvector(q01, 1));
 
-    x[0] = 0; a = aadd_getvalue(q000, x); test_assert(a == weight_lookup(cmake(3.0, 0.0)));
+    x[0] = 0; a = aadd_getvalue(q000, x); test_assert(a == complex_lookup(3.0, 0.0));
     x[0] = 1; a = aadd_getvalue(q000, x); test_assert(a == AADD_ZERO);
-    x[0] = 0; a = aadd_getvalue(q001, x); test_assert(a == weight_lookup(cmake(2.0, 0.0)));
+    x[0] = 0; a = aadd_getvalue(q001, x); test_assert(a == complex_lookup(2.0, 0.0));
     x[0] = 1; a = aadd_getvalue(q001, x); test_assert(a == AADD_ONE);
-    x[0] = 0; a = aadd_getvalue(q010, x); test_assert(a == weight_lookup(cmake(2.0, 0.0)));
+    x[0] = 0; a = aadd_getvalue(q010, x); test_assert(a == complex_lookup(2.0, 0.0));
     x[0] = 1; a = aadd_getvalue(q010, x); test_assert(a == AADD_ONE);
-    x[0] = 0; a = aadd_getvalue(q100, x); test_assert(a == weight_lookup(cmake(2.0, 0.0)));
+    x[0] = 0; a = aadd_getvalue(q100, x); test_assert(a == complex_lookup(2.0, 0.0));
     x[0] = 1; a = aadd_getvalue(q100, x); test_assert(a == AADD_ONE);
     test_assert(q001 == q010);
     test_assert(q001 == q100);
@@ -229,7 +230,7 @@ int test_vector_addition()
     // q0 + q0
     x4[3] = 0; x4[2] = 0; x4[1] = 0; x4[0] = 0; a = aadd_getvalue(q00, x4); test_assert(a == AADD_ZERO);
     x4[3] = 0; x4[2] = 0; x4[1] = 0; x4[0] = 1; a = aadd_getvalue(q00, x4); test_assert(a == AADD_ZERO);
-    x4[3] = 0; x4[2] = 0; x4[1] = 1; x4[0] = 0; a = aadd_getvalue(q00, x4); test_assert(a == weight_lookup(cmake(2.0, 0.0)));
+    x4[3] = 0; x4[2] = 0; x4[1] = 1; x4[0] = 0; a = aadd_getvalue(q00, x4); test_assert(a == complex_lookup(2.0, 0.0));
     x4[3] = 0; x4[2] = 0; x4[1] = 1; x4[0] = 1; a = aadd_getvalue(q00, x4); test_assert(a == AADD_ZERO);
     x4[3] = 0; x4[2] = 1; x4[1] = 0; x4[0] = 0; a = aadd_getvalue(q00, x4); test_assert(a == AADD_ZERO);
     x4[3] = 0; x4[2] = 1; x4[1] = 0; x4[0] = 1; a = aadd_getvalue(q00, x4); test_assert(a == AADD_ZERO);
@@ -276,7 +277,7 @@ int test_vector_addition()
     x4[3] = 0; x4[2] = 1; x4[1] = 1; x4[0] = 1; a = aadd_getvalue(q11, x4); test_assert(a == AADD_ZERO);
     x4[3] = 1; x4[2] = 0; x4[1] = 0; x4[0] = 0; a = aadd_getvalue(q11, x4); test_assert(a == AADD_ZERO);
     x4[3] = 1; x4[2] = 0; x4[1] = 0; x4[0] = 1; a = aadd_getvalue(q11, x4); test_assert(a == AADD_ZERO);
-    x4[3] = 1; x4[2] = 0; x4[1] = 1; x4[0] = 0; a = aadd_getvalue(q11, x4); test_assert(a == weight_lookup(cmake(2.0, 0.0)));
+    x4[3] = 1; x4[2] = 0; x4[1] = 1; x4[0] = 0; a = aadd_getvalue(q11, x4); test_assert(a == complex_lookup(2.0, 0.0));
     x4[3] = 1; x4[2] = 0; x4[1] = 1; x4[0] = 1; a = aadd_getvalue(q11, x4); test_assert(a == AADD_ZERO);
     x4[3] = 1; x4[2] = 1; x4[1] = 0; x4[0] = 0; a = aadd_getvalue(q11, x4); test_assert(a == AADD_ZERO);
     x4[3] = 1; x4[2] = 1; x4[1] = 0; x4[0] = 1; a = aadd_getvalue(q11, x4); test_assert(a == AADD_ZERO);
@@ -287,7 +288,7 @@ int test_vector_addition()
     // q0 + q0 + q0
     x4[3] = 0; x4[2] = 0; x4[1] = 0; x4[0] = 0; a = aadd_getvalue(q000, x4); test_assert(a == AADD_ZERO);
     x4[3] = 0; x4[2] = 0; x4[1] = 0; x4[0] = 1; a = aadd_getvalue(q000, x4); test_assert(a == AADD_ZERO);
-    x4[3] = 0; x4[2] = 0; x4[1] = 1; x4[0] = 0; a = aadd_getvalue(q000, x4); test_assert(a == weight_lookup(cmake(3.0, 0.0)));
+    x4[3] = 0; x4[2] = 0; x4[1] = 1; x4[0] = 0; a = aadd_getvalue(q000, x4); test_assert(a == complex_lookup(3.0, 0.0));
     x4[3] = 0; x4[2] = 0; x4[1] = 1; x4[0] = 1; a = aadd_getvalue(q000, x4); test_assert(a == AADD_ZERO);
     x4[3] = 0; x4[2] = 1; x4[1] = 0; x4[0] = 0; a = aadd_getvalue(q000, x4); test_assert(a == AADD_ZERO);
     x4[3] = 0; x4[2] = 1; x4[1] = 0; x4[0] = 1; a = aadd_getvalue(q000, x4); test_assert(a == AADD_ZERO);
@@ -306,7 +307,7 @@ int test_vector_addition()
     // q0 + q0 + q1 / q0 + q1 + q0 / q1 + q0 + q0
     x4[3] = 0; x4[2] = 0; x4[1] = 0; x4[0] = 1; a = aadd_getvalue(q001, x4); test_assert(a == AADD_ZERO);
     x4[3] = 0; x4[2] = 0; x4[1] = 0; x4[0] = 0; a = aadd_getvalue(q001, x4); test_assert(a == AADD_ZERO);
-    x4[3] = 0; x4[2] = 0; x4[1] = 1; x4[0] = 0; a = aadd_getvalue(q001, x4); test_assert(a == weight_lookup(cmake(2.0, 0.0)));
+    x4[3] = 0; x4[2] = 0; x4[1] = 1; x4[0] = 0; a = aadd_getvalue(q001, x4); test_assert(a == complex_lookup(2.0, 0.0));
     x4[3] = 0; x4[2] = 0; x4[1] = 1; x4[0] = 1; a = aadd_getvalue(q001, x4); test_assert(a == AADD_ZERO);
     x4[3] = 0; x4[2] = 1; x4[1] = 0; x4[0] = 0; a = aadd_getvalue(q001, x4); test_assert(a == AADD_ZERO);
     x4[3] = 0; x4[2] = 1; x4[1] = 0; x4[0] = 1; a = aadd_getvalue(q001, x4); test_assert(a == AADD_ZERO);

--- a/test/test_qmdd_circuits.c
+++ b/test/test_qmdd_circuits.c
@@ -3,6 +3,7 @@
 #include <time.h>
 
 #include "qsylvan.h"
+#include <sylvan_edge_weights_complex.h>
 #include "test_assert.h"
 
 bool VERBOSE = true;
@@ -93,16 +94,16 @@ int test_cswap_circuit()
     x3[2] = 0; x3[1] = 0; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 0; x3[1] = 1; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 0; x3[1] = 1; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
-    x3[2] = 1; x3[1] = 0; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
-    x3[2] = 1; x3[1] = 0; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+    x3[2] = 1; x3[1] = 0; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
+    x3[2] = 1; x3[1] = 0; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
     x3[2] = 1; x3[1] = 1; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 1; x3[1] = 1; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     q = qmdd_ccircuit(q, CIRCID_swap, cs, 1, 2); // control is |+>, expected output: 1/sqrt(2)(|100> + |011>)
     x3[2] = 0; x3[1] = 0; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 0; x3[1] = 0; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 0; x3[1] = 1; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
-    x3[2] = 0; x3[1] = 1; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
-    x3[2] = 1; x3[1] = 0; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+    x3[2] = 0; x3[1] = 1; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
+    x3[2] = 1; x3[1] = 0; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
     x3[2] = 1; x3[1] = 0; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 1; x3[1] = 1; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 1; x3[1] = 1; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
@@ -115,16 +116,16 @@ int test_cswap_circuit()
     x3[2] = 0; x3[1] = 0; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 0; x3[1] = 1; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 0; x3[1] = 1; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
-    x3[2] = 1; x3[1] = 0; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
-    x3[2] = 1; x3[1] = 0; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == weight_lookup(cmake(-1.0/flt_sqrt(2.0),0)));
+    x3[2] = 1; x3[1] = 0; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
+    x3[2] = 1; x3[1] = 0; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == complex_lookup(-1.0/flt_sqrt(2.0),0));
     x3[2] = 1; x3[1] = 1; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 1; x3[1] = 1; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     q = qmdd_ccircuit(q, CIRCID_swap, cs, 1, 2); // control is |->, expected output: 1/sqrt(2)(|100> - |011>)
     x3[2] = 0; x3[1] = 0; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 0; x3[1] = 0; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 0; x3[1] = 1; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
-    x3[2] = 0; x3[1] = 1; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == weight_lookup(cmake(-1.0/flt_sqrt(2.0),0)));
-    x3[2] = 1; x3[1] = 0; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+    x3[2] = 0; x3[1] = 1; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == complex_lookup(-1.0/flt_sqrt(2.0),0));
+    x3[2] = 1; x3[1] = 0; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
     x3[2] = 1; x3[1] = 0; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 1; x3[1] = 1; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 1; x3[1] = 1; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
@@ -137,16 +138,16 @@ int test_cswap_circuit()
     x3[2] = 0; x3[1] = 0; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 0; x3[1] = 1; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 0; x3[1] = 1; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
-    x3[2] = 1; x3[1] = 0; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
-    x3[2] = 1; x3[1] = 0; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == weight_lookup(cmake(0,1.0/flt_sqrt(2.0))));
+    x3[2] = 1; x3[1] = 0; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
+    x3[2] = 1; x3[1] = 0; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == complex_lookup(0,1.0/flt_sqrt(2.0)));
     x3[2] = 1; x3[1] = 1; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 1; x3[1] = 1; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     q = qmdd_ccircuit(q, CIRCID_swap, cs, 1, 2); // control is |+i>, expected output: 1/sqrt(2)(|100> + i|011>)
     x3[2] = 0; x3[1] = 0; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 0; x3[1] = 0; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 0; x3[1] = 1; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
-    x3[2] = 0; x3[1] = 1; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == weight_lookup(cmake(0,1.0/flt_sqrt(2.0))));
-    x3[2] = 1; x3[1] = 0; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+    x3[2] = 0; x3[1] = 1; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == complex_lookup(0,1.0/flt_sqrt(2.0)));
+    x3[2] = 1; x3[1] = 0; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
     x3[2] = 1; x3[1] = 0; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 1; x3[1] = 1; x3[0] = 0; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
     x3[2] = 1; x3[1] = 1; x3[0] = 1; a = aadd_getvalue(q, x3); test_assert(a == AADD_ZERO);
@@ -348,23 +349,23 @@ int test_measurements()
         q   = qmdd_gate(q, GATEID_H, 0);
         q   = qmdd_gate(q, GATEID_H, 1);
         q   = qmdd_cgate(q,GATEID_Z, 0, 1);
-        x2[1]=0; x2[0]=0; a = aadd_getvalue(q, x2); test_assert(a == weight_lookup(cmake(0.5,0)));
-        x2[1]=0; x2[0]=1; a = aadd_getvalue(q, x2); test_assert(a == weight_lookup(cmake(0.5,0)));
-        x2[1]=1; x2[0]=0; a = aadd_getvalue(q, x2); test_assert(a == weight_lookup(cmake(0.5,0)));
-        x2[1]=1; x2[0]=1; a = aadd_getvalue(q, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
+        x2[1]=0; x2[0]=0; a = aadd_getvalue(q, x2); test_assert(a == complex_lookup(0.5,0));
+        x2[1]=0; x2[0]=1; a = aadd_getvalue(q, x2); test_assert(a == complex_lookup(0.5,0));
+        x2[1]=1; x2[0]=0; a = aadd_getvalue(q, x2); test_assert(a == complex_lookup(0.5,0));
+        x2[1]=1; x2[0]=1; a = aadd_getvalue(q, x2); test_assert(a == complex_lookup(-0.5,0));
         qPM = qmdd_measure_qubit(q, 0, 2, &m, &prob);
         test_assert(flt_abs(prob - 0.5) < cmap_get_tolerance());
         if (m == 0) { // expect 1/sqrt(2)(|00> + |10>)
-            x2[1]=0; x2[0]=0; a = aadd_getvalue(qPM, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+            x2[1]=0; x2[0]=0; a = aadd_getvalue(qPM, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
             x2[1]=0; x2[0]=1; a = aadd_getvalue(qPM, x2); test_assert(a == AADD_ZERO);
-            x2[1]=1; x2[0]=0; a = aadd_getvalue(qPM, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+            x2[1]=1; x2[0]=0; a = aadd_getvalue(qPM, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
             x2[1]=1; x2[0]=1; a = aadd_getvalue(qPM, x2); test_assert(a == AADD_ZERO);
         }
         if (m == 1) { // expect 1/sqrt(2)(|01> - |11>)
             x2[1]=0; x2[0]=0; a = aadd_getvalue(qPM, x2); test_assert(a == AADD_ZERO);
-            x2[1]=0; x2[0]=1; a = aadd_getvalue(qPM, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+            x2[1]=0; x2[0]=1; a = aadd_getvalue(qPM, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
             x2[1]=1; x2[0]=0; a = aadd_getvalue(qPM, x2); test_assert(a == AADD_ZERO);
-            x2[1]=1; x2[0]=1; a = aadd_getvalue(qPM, x2); test_assert(a == weight_lookup(cmake(-1.0/flt_sqrt(2.0),0)));
+            x2[1]=1; x2[0]=1; a = aadd_getvalue(qPM, x2); test_assert(a == complex_lookup(-1.0/flt_sqrt(2.0),0));
         }
     }
 

--- a/test/test_qmdd_gates.c
+++ b/test/test_qmdd_gates.c
@@ -3,6 +3,7 @@
 
 #include "qsylvan.h"
 #include "test_assert.h"
+#include <sylvan_edge_weights_complex.h>
 
 bool VERBOSE = true;
 
@@ -116,10 +117,10 @@ int test_h_gate()
     q0 = qmdd_gate(q0, GATEID_H, 0);
     q1 = qmdd_gate(q1, GATEID_H, 0);
 
-    x[0] = 0; a = aadd_getvalue(q0, x); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
-    x[0] = 1; a = aadd_getvalue(q0, x); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
-    x[0] = 0; a = aadd_getvalue(q1, x); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
-    x[0] = 1; a = aadd_getvalue(q1, x); test_assert(a == weight_lookup(cmake(-1.0/flt_sqrt(2.0),0)));
+    x[0] = 0; a = aadd_getvalue(q0, x); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
+    x[0] = 1; a = aadd_getvalue(q0, x); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
+    x[0] = 0; a = aadd_getvalue(q1, x); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
+    x[0] = 1; a = aadd_getvalue(q1, x); test_assert(a == complex_lookup(-1.0/flt_sqrt(2.0),0));
 
 
     // Two qubit test
@@ -139,31 +140,31 @@ int test_h_gate()
     test_assert(aadd_is_ordered(q5, nqubits));
 
     // q2 = |0+>
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q2, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q2, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q2, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q2, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
     x2[1] = 1; x2[0] = 0; a = aadd_getvalue(q2, x2); test_assert(a == AADD_ZERO);
     x2[1] = 1; x2[0] = 1; a = aadd_getvalue(q2, x2); test_assert(a == AADD_ZERO);
     test_assert(aadd_countnodes(q2) == 2);
 
     // q3 = |0->
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q3, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q3, x2); test_assert(a == weight_lookup(cmake(-1.0/flt_sqrt(2.0),0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q3, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q3, x2); test_assert(a == complex_lookup(-1.0/flt_sqrt(2.0),0));
     x2[1] = 1; x2[0] = 0; a = aadd_getvalue(q3, x2); test_assert(a == AADD_ZERO);
     x2[1] = 1; x2[0] = 1; a = aadd_getvalue(q3, x2); test_assert(a == AADD_ZERO);
     test_assert(aadd_countnodes(q3) == 3);
 
     // q4 = |+0>
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q4, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q4, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
     x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q4, x2); test_assert(a == AADD_ZERO);
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(q4, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(q4, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
     x2[1] = 1; x2[0] = 1; a = aadd_getvalue(q4, x2); test_assert(a == AADD_ZERO);
     test_assert(aadd_countnodes(q4) == 2);
 
     // q5 = |++>
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q5, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q5, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(q5, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(q5, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q5, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q5, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(q5, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(q5, x2); test_assert(a == complex_lookup(0.5, 0));
     test_assert(aadd_countnodes(q5) == 1);
 
     if(VERBOSE) printf("qmdd h gates:              ok\n");
@@ -202,37 +203,37 @@ int test_phase_gates()
     test_assert(q0 == qTTdag);
     test_assert(q0 == qTdagT);
 
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(0.5, 0));
     test_assert(aadd_countnodes(q0) == 1);
 
     q0 = qmdd_gate(q0, GATEID_Z, 0);
 
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(-0.5,0));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(-0.5,0));
     test_assert(aadd_countnodes(q0) == 2);
 
     q0 = qmdd_gate(q0, GATEID_Z, 0);
     q0 = qmdd_gate(q0, GATEID_Z, 1);
 
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(-0.5,0));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(-0.5,0));
     test_assert(aadd_countnodes(q0) == 2);
 
     q0 = qmdd_gate(q0, GATEID_Z, 1);
     q0 = qmdd_gate(q0, GATEID_S, 0);
     q0 = qmdd_gate(q0, GATEID_S, 0);
 
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(-0.5,0));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(-0.5,0));
     test_assert(aadd_countnodes(q0) == 2);
 
     q0 = qmdd_gate(q0, GATEID_Z, 0);
@@ -241,10 +242,10 @@ int test_phase_gates()
     q0 = qmdd_gate(q0, GATEID_T, 1);
     q0 = qmdd_gate(q0, GATEID_T, 1);
 
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(-0.5,0));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(-0.5,0));
     test_assert(aadd_countnodes(q0) == 2);
 
     q0 = qmdd_gate(q0, GATEID_Z, 1);
@@ -253,20 +254,20 @@ int test_phase_gates()
     q0 = qmdd_gate(q0, GATEID_Tdag, 1);
     q0 = qmdd_gate(q0, GATEID_Tdag, 1);
 
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(-0.5,0));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(-0.5,0));
     test_assert(aadd_countnodes(q0) == 2);
 
     q0 = qmdd_gate(q0, GATEID_Z, 1);
     q0 = qmdd_gate(q0, GATEID_Sdag, 1);
     q0 = qmdd_gate(q0, GATEID_Sdag, 1);
 
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(-0.5,0));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(q0, x2); test_assert(a == complex_lookup(-0.5,0));
     test_assert(aadd_countnodes(q0) == 2);
 
     // check R_k gates
@@ -411,18 +412,18 @@ int test_cx_gate()
     x2[1] = 0; x2[0] = 0; qBell = qmdd_create_basis_state(2, x2);
     qBell = qmdd_gate(qBell, GATEID_H, 0);
     
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(qBell, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(qBell, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(qBell, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(qBell, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
     x2[1] = 1; x2[0] = 0; a = aadd_getvalue(qBell, x2); test_assert(a == AADD_ZERO);
     x2[1] = 1; x2[0] = 1; a = aadd_getvalue(qBell, x2); test_assert(a == AADD_ZERO);
     test_assert(aadd_countnodes(qBell) == 2);
 
     qBell = qmdd_cgate(qBell, GATEID_X, 0, 1);
 
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(qBell, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(qBell, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
     x2[1] = 0; x2[0] = 1; a = aadd_getvalue(qBell, x2); test_assert(a == AADD_ZERO);
     x2[1] = 1; x2[0] = 0; a = aadd_getvalue(qBell, x2); test_assert(a == AADD_ZERO);
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(qBell, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(qBell, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
     test_assert(aadd_countnodes(qBell) == 4);
 
     // TODO: more tests
@@ -442,18 +443,18 @@ int test_cz_gate()
     qGraph = qmdd_gate(qGraph, GATEID_H, 0);
     qGraph = qmdd_gate(qGraph, GATEID_H, 1);
 
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(qGraph, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(qGraph, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(qGraph, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(qGraph, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(qGraph, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(qGraph, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(qGraph, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(qGraph, x2); test_assert(a == complex_lookup(0.5, 0));
     test_assert(aadd_countnodes(qGraph) == 1);
 
     qGraph = qmdd_cgate(qGraph, GATEID_Z, 0, 1);
 
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(qGraph, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(qGraph, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(qGraph, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(qGraph, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(qGraph, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(qGraph, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(qGraph, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(qGraph, x2); test_assert(a == complex_lookup(-0.5,0));
     test_assert(aadd_countnodes(qGraph) == 3);
 
     if(VERBOSE) printf("qmdd CZ gates:             ok\n");
@@ -472,13 +473,14 @@ int test_ccz_gate()
     q3 = qmdd_gate(q3, GATEID_H, 2);
     aRef = aadd_getvalue(q3, x3);
 
+    complex_t mone = cmone();
     x3[2]=1; x3[1]=0; x3[0]=1; q3 = qmdd_all_control_phase(q3, 3, x3);
     x3[2] = 0; x3[1] = 0; x3[0] = 0; a = aadd_getvalue(q3, x3); test_assert(a == aRef);
     x3[2] = 0; x3[1] = 0; x3[0] = 1; a = aadd_getvalue(q3, x3); test_assert(a == aRef);
     x3[2] = 0; x3[1] = 1; x3[0] = 0; a = aadd_getvalue(q3, x3); test_assert(a == aRef);
     x3[2] = 0; x3[1] = 1; x3[0] = 1; a = aadd_getvalue(q3, x3); test_assert(a == aRef);
     x3[2] = 1; x3[1] = 0; x3[0] = 0; a = aadd_getvalue(q3, x3); test_assert(a == aRef);    
-    x3[2] = 1; x3[1] = 0; x3[0] = 1; a = aadd_getvalue(q3, x3); test_assert(a == wgt_mul(aRef,weight_lookup(cmone())));
+    x3[2] = 1; x3[1] = 0; x3[0] = 1; a = aadd_getvalue(q3, x3); test_assert(a == wgt_mul(aRef,weight_lookup(&mone)));
     x3[2] = 1; x3[1] = 1; x3[0] = 0; a = aadd_getvalue(q3, x3); test_assert(a == aRef);
     x3[2] = 1; x3[1] = 1; x3[0] = 1; a = aadd_getvalue(q3, x3); test_assert(a == aRef);
     test_assert(aadd_is_ordered(q3, 3));
@@ -496,11 +498,12 @@ int test_controlled_range_gate()
     AMP a, aRef, aRefMin;
     bool *x_bits;
 
+    complex_t mone = cmone();
     BDDVAR nqubits = 10;
     q10 = qmdd_create_basis_state(10, x10);
     for (BDDVAR k = 0; k < nqubits; k++) q10 = qmdd_gate(q10, GATEID_H, k);
     aRef = aadd_getvalue(q10, x10);
-    aRefMin = wgt_mul(aRef, weight_lookup(cmone()));
+    aRefMin = wgt_mul(aRef, weight_lookup(&mone));
 
     // assert |++..+> state
     test_assert(aadd_is_ordered(q10, nqubits));

--- a/test/test_qmdd_matrix.c
+++ b/test/test_qmdd_matrix.c
@@ -2,6 +2,7 @@
 #include <time.h>
 
 #include "qsylvan.h"
+#include <sylvan_edge_weights_complex.h>
 #include "test_assert.h"
 
 bool VERBOSE = true;
@@ -105,10 +106,10 @@ int test_h_gate()
     v0 = aadd_matvec_mult(mH, v0, nqubits);
     v1 = aadd_matvec_mult(mH, v1, nqubits);
 
-    x[0] = 1; a = aadd_getvalue(v0, x); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
-    x[0] = 0; a = aadd_getvalue(v0, x); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
-    x[0] = 0; a = aadd_getvalue(v1, x); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
-    x[0] = 1; a = aadd_getvalue(v1, x); test_assert(a == weight_lookup(cmake(-1.0/flt_sqrt(2.0),0)));
+    x[0] = 1; a = aadd_getvalue(v0, x); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
+    x[0] = 0; a = aadd_getvalue(v0, x); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
+    x[0] = 0; a = aadd_getvalue(v1, x); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
+    x[0] = 1; a = aadd_getvalue(v1, x); test_assert(a == complex_lookup(-1.0/flt_sqrt(2.0),0));
 
     // matrix-matrix mult
     mTemp = aadd_matmat_mult(mI, mH, nqubits); test_assert(mTemp == mH);
@@ -148,38 +149,38 @@ int test_h_gate()
     v6 = aadd_matvec_mult(mHH, v6, nqubits); // v6 = |-+>
 
     // v2 = |0+>
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v2, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v2, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v2, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v2, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
     x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v2, x2); test_assert(a == AADD_ZERO);
     x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v2, x2); test_assert(a == AADD_ZERO);
     test_assert(aadd_countnodes(v2) == 2);
 
     // v3 = |0->
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v3, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v3, x2); test_assert(a == weight_lookup(cmake(-1.0/flt_sqrt(2.0),0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v3, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v3, x2); test_assert(a == complex_lookup(-1.0/flt_sqrt(2.0),0));
     x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v3, x2); test_assert(a == AADD_ZERO);
     x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v3, x2); test_assert(a == AADD_ZERO);
     test_assert(aadd_countnodes(v3) == 3);
 
     // v4 = |+0>
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v4, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v4, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
     x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v4, x2); test_assert(a == AADD_ZERO);
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v4, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v4, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
     x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v4, x2); test_assert(a == AADD_ZERO);
     test_assert(aadd_countnodes(v4) == 2);
 
     // v5 = |++>
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v5, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v5, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v5, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v5, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v5, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v5, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v5, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v5, x2); test_assert(a == complex_lookup(0.5, 0));
     test_assert(aadd_countnodes(v5) == 1);
 
     // v6 = |-+>
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v6, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v6, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v6, x2); test_assert(a == weight_lookup(cmake(-0.5, 0)));
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v6, x2); test_assert(a == weight_lookup(cmake(-0.5, 0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v6, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v6, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v6, x2); test_assert(a == complex_lookup(-0.5, 0));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v6, x2); test_assert(a == complex_lookup(-0.5, 0));
     test_assert(aadd_countnodes(v6) == 2);
 
     // matrix-matrix mult
@@ -274,37 +275,37 @@ int test_phase_gates()
 
 
     // more matrix-vector mult    
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
     test_assert(aadd_countnodes(v0) == 1);
 
     v0 = aadd_matvec_mult(mZ0, v0, nqubits);
 
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(-0.5,0));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(-0.5,0));
     test_assert(aadd_countnodes(v0) == 2);
 
     v0 = aadd_matvec_mult(mZ0, v0, nqubits);
     v0 = aadd_matvec_mult(mZ1, v0, nqubits);
 
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(-0.5,0));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(-0.5,0));
     test_assert(aadd_countnodes(v0) == 2);
 
     v0 = aadd_matvec_mult(mZ1, v0, nqubits);
     v0 = aadd_matvec_mult(mS0, v0, nqubits);
     v0 = aadd_matvec_mult(mS0, v0, nqubits);
 
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(-0.5,0));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(-0.5,0));
     test_assert(aadd_countnodes(v0) == 2);
 
     v0 = aadd_matvec_mult(mZ0, v0, nqubits);
@@ -313,10 +314,10 @@ int test_phase_gates()
     v0 = aadd_matvec_mult(mT1, v0, nqubits);
     v0 = aadd_matvec_mult(mT1, v0, nqubits);
 
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(-0.5,0));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(-0.5,0));
     test_assert(aadd_countnodes(v0) == 2);
 
     v0 = aadd_matvec_mult(mZ1,    v0, nqubits);
@@ -325,10 +326,10 @@ int test_phase_gates()
     v0 = aadd_matvec_mult(mTdag1, v0, nqubits);
     v0 = aadd_matvec_mult(mTdag1, v0, nqubits);
 
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(-0.5,0));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(-0.5,0));
     test_assert(aadd_countnodes(v0) == 2);
     
 
@@ -374,17 +375,17 @@ int test_cx_gate()
 
     // matrix-vector mult
     v0 = aadd_matvec_mult(mH0, v0, nqubits);
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
     x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == AADD_ZERO);
     x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == AADD_ZERO);
     test_assert(aadd_countnodes(v0) == 2);
 
     v0 = aadd_matvec_mult(mCNOT, v0, nqubits);
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
     x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == AADD_ZERO);
     x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == AADD_ZERO);
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
     test_assert(aadd_countnodes(v0) == 4);
 
     // same as above but multiplies H CNOT first before applying to the state
@@ -392,10 +393,10 @@ int test_cx_gate()
     mTemp = aadd_matmat_mult(mCNOT, mH0, nqubits);
     v0 = qmdd_create_all_zero_state(nqubits);
     v0 = aadd_matvec_mult(mTemp, v0, nqubits);
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
     x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == AADD_ZERO);
     x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == AADD_ZERO);
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
     test_assert(aadd_countnodes(v0) == 4);
 
     // If we did H0 CNOT |00> instead then the CNOT would not have an effect, 
@@ -405,8 +406,8 @@ int test_cx_gate()
     mTemp = aadd_matmat_mult(mH0, mCNOT, nqubits);
     v0 = qmdd_create_all_zero_state(nqubits);
     v0 = aadd_matvec_mult(mTemp, v0, nqubits);
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(1.0/flt_sqrt(2.0),0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(1.0/flt_sqrt(2.0),0));
     x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == AADD_ZERO);
     x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == AADD_ZERO);
     test_assert(aadd_countnodes(v0) == 2);
@@ -436,18 +437,18 @@ int test_cz_gate()
     v0 = aadd_matvec_mult(mH0, v0, nqubits);
     v0 = aadd_matvec_mult(mH1, v0, nqubits);
 
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
     test_assert(aadd_countnodes(v0) == 1);
 
     v0 = aadd_matvec_mult(mCZ, v0, nqubits);
 
-    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(0.5, 0)));
-    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == weight_lookup(cmake(-0.5,0)));
+    x2[1] = 0; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 0; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 0; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(0.5, 0));
+    x2[1] = 1; x2[0] = 1; a = aadd_getvalue(v0, x2); test_assert(a == complex_lookup(-0.5,0));
     test_assert(aadd_countnodes(v0) == 3);
 
     // TODO: test with slightly more qubits

--- a/test/test_qmdd_normalization.c
+++ b/test/test_qmdd_normalization.c
@@ -2,6 +2,7 @@
 #include <time.h>
 
 #include "qsylvan.h"
+#include <sylvan_edge_weights_complex.h>
 #include "test_assert.h"
 
 bool VERBOSE = true;
@@ -13,8 +14,8 @@ int test_wgt_norm_L2()
     complex_t wa, wb, wc, wr, wref, wref2;
 
     // a = 1/sqrt(2), b = 1/sqrt(2) (squares already sum to 1)
-    a = weight_lookup(cmake(1.0/flt_sqrt(2.0), 0));
-    b = weight_lookup(cmake(1.0/flt_sqrt(2.0), 0));
+    a = complex_lookup(1.0/flt_sqrt(2.0), 0);
+    b = complex_lookup(1.0/flt_sqrt(2.0), 0);
     _a = a;
     _b = b;
     c = wgt_norm_L2(&a, &b);
@@ -35,8 +36,8 @@ int test_wgt_norm_L2()
     test_assert(a_recomputed == a);
 
     // a = 1/sqrt(2), b = -1/sqrt(2) (squares already sum to 1)
-    a = weight_lookup(cmake(1.0/flt_sqrt(2.0), 0));
-    b = weight_lookup(cmake(-1.0/flt_sqrt(2.0), 0));
+    a = complex_lookup(1.0/flt_sqrt(2.0), 0);
+    b = complex_lookup(-1.0/flt_sqrt(2.0), 0);
     _a = a;
     _b = b;
     c = wgt_norm_L2(&a, &b);
@@ -56,8 +57,8 @@ int test_wgt_norm_L2()
     test_assert(a_recomputed == a);
 
     // a = -1/sqrt(2), b = 1/sqrt(2) (squares already sum to 1, but a not in R)
-    a = weight_lookup(cmake(-1.0/flt_sqrt(2.0), 0));
-    b = weight_lookup(cmake(1.0/flt_sqrt(2.0), 0));
+    a = complex_lookup(-1.0/flt_sqrt(2.0), 0);
+    b = complex_lookup(1.0/flt_sqrt(2.0), 0);
     _a = a;
     _b = b;
     c = wgt_norm_L2(&a, &b);
@@ -77,8 +78,8 @@ int test_wgt_norm_L2()
     test_assert(a_recomputed == a);
 
     // a = 5, b = 3 (squares of a and b don't sum to 1)
-    a = weight_lookup(cmake(5, 0));
-    b = weight_lookup(cmake(3, 0));
+    a = complex_lookup(5, 0);
+    b = complex_lookup(3, 0);
     c = wgt_norm_L2(&a, &b);
     a_recomputed = wgt_get_low_L2normed(b);
 
@@ -102,8 +103,8 @@ int test_wgt_norm_L2()
     test_assert(a_recomputed == a);
 
     // a = 5, b = 0
-    a = weight_lookup(cmake(5, 0));
-    b = weight_lookup(cmake(0, 0));
+    a = complex_lookup(5, 0);
+    b = complex_lookup(0, 0);
     c = wgt_norm_L2(&a, &b);
     a_recomputed = wgt_get_low_L2normed(b);
 
@@ -120,8 +121,8 @@ int test_wgt_norm_L2()
     test_assert(a_recomputed == a);
 
     // a = 0, b = 0.3
-    a = weight_lookup(cmake(0, 0));
-    b = weight_lookup(cmake(0.3, 0));
+    a = complex_lookup(0, 0);
+    b = complex_lookup(0.3, 0);
     c = wgt_norm_L2(&a, &b);
     a_recomputed = wgt_get_low_L2normed(b);
 
@@ -138,7 +139,7 @@ int test_wgt_norm_L2()
     test_assert(a_recomputed == a);
 
     // a = 2, b = 1
-    a = weight_lookup(cmake(2, 0));
+    a = complex_lookup(2, 0);
     b = AADD_ONE;
     c = wgt_norm_L2(&a, &b);
     a_recomputed = wgt_get_low_L2normed(b);
@@ -155,7 +156,7 @@ int test_wgt_norm_L2()
 
     // a = 1, b = i
     a = AADD_ONE;
-    b = weight_lookup(cmake(0, 1));
+    b = complex_lookup(0, 1);
     c = wgt_norm_L2(&a, &b);
     a_recomputed = wgt_get_low_L2normed(b);
 
@@ -170,8 +171,8 @@ int test_wgt_norm_L2()
     test_assert(a_recomputed == a);
 
     // a = (1 + i)/2, b = (1 - i)/2 (magnitude 1/sqrt(2) phase difference of -i)
-    a = weight_lookup(cmake(0.5, 0.5));
-    b = weight_lookup(cmake(0.5, -0.5));
+    a = complex_lookup(0.5, 0.5);
+    b = complex_lookup(0.5, -0.5);
     c = wgt_norm_L2(&a, &b);
     a_recomputed = wgt_get_low_L2normed(b);
 

--- a/test/test_zdd.c
+++ b/test/test_zdd.c
@@ -782,8 +782,8 @@ TASK_0(int, runtests)
     for (int k=0; k<test_iterations; k++) if (CALL(test_zdd_exists)) return 1;
     // for (int k=0; k<test_iterations; k++) if (CALL(test_zdd_relnext)) return 1;
     // for (int k=0; k<test_iterations; k++) if (CALL(test_zdd_and_dom)) return 1;
-    printf("test_zdd_read_write...\n");
-    for (int k=0; k<10; k++) if (CALL(test_zdd_read_write)) return 1;
+    // printf("test_zdd_read_write...\n");
+    // for (int k=0; k<10; k++) if (CALL(test_zdd_read_write)) return 1;
     // for (int k=0; k<test_iterations; k++) if (CALL(test_zdd_extend_domain)) return 1;
     printf("test_zdd_isop_basic...\n");
     if (CALL(test_zdd_isop_basic)) return 1;

--- a/test/test_zdd.c
+++ b/test/test_zdd.c
@@ -754,7 +754,7 @@ TASK_0(int, runtests)
     // Testing without garbage collection
     sylvan_gc_disable();
 
-    int test_iterations = 1000;
+    int test_iterations = 10;
 
     printf("test_zdd_eval...\n");
     for (int i=0; i<test_iterations; i++) if (CALL(test_zdd_eval)) return 1;
@@ -783,7 +783,7 @@ TASK_0(int, runtests)
     // for (int k=0; k<test_iterations; k++) if (CALL(test_zdd_relnext)) return 1;
     // for (int k=0; k<test_iterations; k++) if (CALL(test_zdd_and_dom)) return 1;
     printf("test_zdd_read_write...\n");
-    for (int k=0; k<test_iterations; k++) if (CALL(test_zdd_read_write)) return 1;
+    for (int k=0; k<10; k++) if (CALL(test_zdd_read_write)) return 1;
     // for (int k=0; k<test_iterations; k++) if (CALL(test_zdd_extend_domain)) return 1;
     printf("test_zdd_isop_basic...\n");
     if (CALL(test_zdd_isop_basic)) return 1;


### PR DESCRIPTION
This patch adds the following:
- Q-Sylvan version update
- update Q-Sylvan to Sylvan base 1.8 (adding proper cross-platform support for atomics)
- add CHANGELOG.md (todo)
- created proper abstract data type weight_t



One test fails for me. I cannot run previous versions so couldn't see whether the patch introduces this behavior.


9/12 Testing: test_qmdd_gates
9/12 Test: test_qmdd_gates
Command: "/Users/laarman/Projects/q-sylvan/test/test_qmdd_gates"
Directory: /Users/laarman/Projects/q-sylvan/test
"test_qmdd_gates" start time: Aug 16 20:35 CEST
Output:
----------------------------------------------------------
file /Users/laarman/Projects/q-sylvan/test/test_qmdd_gates.c: line 357 (int test_pauli_rotation_gates()): precondition `qTest == qRef' failed.
1 worker(s), amps backend = 0, norm strategy = 0:
qmdd x gates:              ok
qmdd h gates:              ok
qmdd phase gates:          ok
<end of output>
Test time =   0.18 sec
----------------------------------------------------------
Test Failed.
"test_qmdd_gates" end time: Aug 16 20:35 CEST
"test_qmdd_gates" time elapsed: 00:00:00
----------------------------------------------------------